### PR TITLE
Support concurrent-ruby 0.9

### DIFF
--- a/expeditor.gemspec
+++ b/expeditor.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "concurrent-ruby", "0.9.0"
-  spec.add_runtime_dependency "concurrent-ruby-ext", "0.9.0"
+  spec.add_runtime_dependency "concurrent-ruby", "~> 0.9.0"
+  spec.add_runtime_dependency "concurrent-ruby-ext", "~> 0.9.0"
   spec.add_runtime_dependency "retryable", "> 1.0"
 
   spec.add_development_dependency "bundler"

--- a/expeditor.gemspec
+++ b/expeditor.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "concurrent-ruby", "0.8.0"
-  spec.add_runtime_dependency "concurrent-ruby-ext", "0.8.0"
+  spec.add_runtime_dependency "concurrent-ruby", "0.9.0"
+  spec.add_runtime_dependency "concurrent-ruby-ext", "0.9.0"
   spec.add_runtime_dependency "retryable", "> 1.0"
 
   spec.add_development_dependency "bundler"

--- a/lib/expeditor/command.rb
+++ b/lib/expeditor/command.rb
@@ -117,11 +117,11 @@ module Expeditor
         if reason != nil
           future = RichFuture.new(executor: Concurrent.global_io_executor) do
             success, val, reason = Concurrent::SafeTaskExecutor.new(block, rescue_exception: true).execute(reason)
-            @fallback_var.complete(success, val, reason)
+            @fallback_var.send(:complete, success, val, reason)
           end
           future.safe_execute
         else
-          @fallback_var.complete(true, value, nil)
+          @fallback_var.send(:complete, true, value, nil)
         end
       end
     end

--- a/lib/expeditor/command.rb
+++ b/lib/expeditor/command.rb
@@ -115,7 +115,7 @@ module Expeditor
       @fallback_var = Concurrent::IVar.new
       @normal_future.add_observer do |_, value, reason|
         if reason != nil
-          future = RichFuture.new(executor: Concurrent.configuration.global_task_pool) do
+          future = RichFuture.new(executor: Concurrent.global_io_executor) do
             success, val, reason = Concurrent::SafeTaskExecutor.new(block, rescue_exception: true).execute(reason)
             @fallback_var.complete(success, val, reason)
           end

--- a/lib/expeditor/rich_future.rb
+++ b/lib/expeditor/rich_future.rb
@@ -22,7 +22,7 @@ module Expeditor
     end
 
     def set(v)
-      super(v)
+      complete(true, v, nil)
     end
 
     def safe_set(v)

--- a/lib/expeditor/rich_future.rb
+++ b/lib/expeditor/rich_future.rb
@@ -41,11 +41,15 @@ module Expeditor
       not unscheduled?
     end
 
-    def safe_execute
-      begin
-        execute
-      rescue Exception => e
-        fail(e)
+    def safe_execute(*args)
+      if args.empty?
+        begin
+          execute
+        rescue Exception => e
+          fail(e)
+        end
+      else
+        super(*args)
       end
     end
   end

--- a/lib/expeditor/rich_future.rb
+++ b/lib/expeditor/rich_future.rb
@@ -48,14 +48,5 @@ module Expeditor
         fail(e)
       end
     end
-
-    private
-
-    # This is workaround for concurrent-ruby's deadlock bug
-    # see: ruby-concurrency/concurrent-ruby#275
-    def work
-      success, val, reason = Concurrent::SafeTaskExecutor.new(@task, rescue_exception: true).execute(*@args)
-      complete(success, val, reason)
-    end
   end
 end

--- a/spec/expeditor/command_spec.rb
+++ b/spec/expeditor/command_spec.rb
@@ -55,12 +55,11 @@ describe Expeditor::Command do
     context 'with thread pool overflow' do
       it 'should throw RejectedExecutionError in #get, not #start' do
         service = Expeditor::Service.new(executor: Concurrent::ThreadPoolExecutor.new(max_threads: 1, min_threads: 1, max_queue: 1))
-        command1 = simple_command(1, service: service)
-        command2 = simple_command(2, service: service)
-        command1.start
-        command2.start
-        expect(command1.get).to eq(1)
-        expect { command2.get }.to raise_error(Expeditor::RejectedExecutionError)
+        commands = 3.times.map do |i|
+          simple_command(i, service: service)
+        end
+        commands.map(&:start)
+        expect { commands.each(&:get) }.to raise_error(Expeditor::RejectedExecutionError)
         service.shutdown
       end
     end

--- a/spec/expeditor/rich_future_spec.rb
+++ b/spec/expeditor/rich_future_spec.rb
@@ -227,7 +227,7 @@ describe Expeditor::RichFuture do
           max_queue: 1,
         )
         futures = 3.times.map do
-          future1 = Expeditor::RichFuture.new(executor: executor) do
+          Expeditor::RichFuture.new(executor: executor) do
             42
           end
         end

--- a/spec/expeditor/rich_future_spec.rb
+++ b/spec/expeditor/rich_future_spec.rb
@@ -226,14 +226,12 @@ describe Expeditor::RichFuture do
           max_threads: 1,
           max_queue: 1,
         )
-        future1 = Expeditor::RichFuture.new(executor: executor) do
-          42
+        futures = 3.times.map do
+          future1 = Expeditor::RichFuture.new(executor: executor) do
+            42
+          end
         end
-        future2 = Expeditor::RichFuture.new(executor: executor) do
-          42
-        end
-        future1.execute
-        expect { future2.execute }.to raise_error(Expeditor::RejectedExecutionError)
+        expect { futures.each(&:execute) }.to raise_error(Expeditor::RejectedExecutionError)
       end
     end
   end


### PR DESCRIPTION
I want to migrate to concurrent-ruby 1.0.0. But there are many breaking changes.
For a safe migration, I want to release a new version with 0.9 support first.

Please see a commit message for a detail of each change.

ref:
https://github.com/ruby-concurrency/concurrent-ruby/compare/v0.8.0...v0.9.0
https://github.com/ruby-concurrency/concurrent-ruby/blob/v0.9.0/CHANGELOG.md