### PR TITLE
Test thread pool overflow properly

### DIFF
--- a/spec/expeditor/command_spec.rb
+++ b/spec/expeditor/command_spec.rb
@@ -55,12 +55,27 @@ describe Expeditor::Command do
     context 'with thread pool overflow' do
       it 'should throw RejectedExecutionError in #get, not #start' do
         service = Expeditor::Service.new(executor: Concurrent::ThreadPoolExecutor.new(max_threads: 1, min_threads: 1, max_queue: 1))
-        command1 = simple_command(1, service: service)
+        mutex = Mutex.new
+        command1 = Expeditor::Command.new(service: service) do
+          begin
+            mutex.lock
+            1
+          ensure
+            mutex.unlock
+          end
+        end
         command2 = simple_command(2, service: service)
+        command3 = simple_command(3, service: service)
+
+        mutex.lock
         command1.start
         command2.start
+        command3.start
+        mutex.unlock
+
         expect(command1.get).to eq(1)
-        expect { command2.get }.to raise_error(Expeditor::RejectedExecutionError)
+        expect(command2.get).to eq(2)
+        expect { command3.get }.to raise_error(Expeditor::RejectedExecutionError)
         service.shutdown
       end
     end

--- a/spec/expeditor/command_spec.rb
+++ b/spec/expeditor/command_spec.rb
@@ -55,11 +55,12 @@ describe Expeditor::Command do
     context 'with thread pool overflow' do
       it 'should throw RejectedExecutionError in #get, not #start' do
         service = Expeditor::Service.new(executor: Concurrent::ThreadPoolExecutor.new(max_threads: 1, min_threads: 1, max_queue: 1))
-        commands = 3.times.map do |i|
-          simple_command(i, service: service)
-        end
-        commands.map(&:start)
-        expect { commands.each(&:get) }.to raise_error(Expeditor::RejectedExecutionError)
+        command1 = simple_command(1, service: service)
+        command2 = simple_command(2, service: service)
+        command1.start
+        command2.start
+        expect(command1.get).to eq(1)
+        expect { command2.get }.to raise_error(Expeditor::RejectedExecutionError)
         service.shutdown
       end
     end

--- a/spec/expeditor/rich_future_spec.rb
+++ b/spec/expeditor/rich_future_spec.rb
@@ -226,14 +226,25 @@ describe Expeditor::RichFuture do
           max_threads: 1,
           max_queue: 1,
         )
+        mutex = Mutex.new
         future1 = Expeditor::RichFuture.new(executor: executor) do
-          42
+          begin
+            mutex.lock
+            42
+          ensure
+            mutex.unlock
+          end
         end
         future2 = Expeditor::RichFuture.new(executor: executor) do
           42
         end
+        future3 = Expeditor::RichFuture.new(executor: executor) do
+          42
+        end
+        mutex.lock
         future1.execute
-        expect { future2.execute }.to raise_error(Expeditor::RejectedExecutionError)
+        future2.execute
+        expect { future3.execute }.to raise_error(Expeditor::RejectedExecutionError)
       end
     end
   end

--- a/spec/expeditor/rich_future_spec.rb
+++ b/spec/expeditor/rich_future_spec.rb
@@ -226,12 +226,14 @@ describe Expeditor::RichFuture do
           max_threads: 1,
           max_queue: 1,
         )
-        futures = 3.times.map do
-          Expeditor::RichFuture.new(executor: executor) do
-            42
-          end
+        future1 = Expeditor::RichFuture.new(executor: executor) do
+          42
         end
-        expect { futures.each(&:execute) }.to raise_error(Expeditor::RejectedExecutionError)
+        future2 = Expeditor::RichFuture.new(executor: executor) do
+          42
+        end
+        future1.execute
+        expect { future2.execute }.to raise_error(Expeditor::RejectedExecutionError)
       end
     end
   end


### PR DESCRIPTION
Fixed tests in https://github.com/k0kubun/expeditor/commit/1d70b125c6543eb84f87f4f89261a18eac51d010 of https://github.com/cookpad/expeditor/pull/2 to test properly and prevent random failure.

### Test execution flow of command_spec 
basically the same as rich_future_spec

- command1 is started
  - worker is created (thread: 1, queue: 0)
  - command1's task is enqueued (thread: 1, queue: 1)
  - the worker pops queue (thread: 1, queue: 0)
  - since mutex is locked, command1's task is blocked (thread: 1, queue: 0)
- command2 is started
  - command2's task is enqueued (thread: 1, queue: 1)
- command3 is started
  - since command3's task can't be enqueued (queue size is max_queue), handle_fallback is called
     - RejectedExecutionError is raised
  - RejectedExecutionError is rescued by #safe_execute
     - RejectedExecutionError is set as reason in #fail
- mutex is unlocked
- command1.get returns 1
- command2.get returns 2
- command3.get raises RejectedExecutionError because reason is set