### PR TITLE
Dcrease horizontal dependencies in spec

### DIFF
--- a/spec/expeditor/command_functions_spec.rb
+++ b/spec/expeditor/command_functions_spec.rb
@@ -92,11 +92,11 @@ describe Expeditor::Command do
 
     context 'with large number of horizontal dependencies ^ 2 (long test case)' do
       it 'should be ok' do
-        commands = 300.times.map do
-          commands = 300.times.map do
+        commands = 100.times.map do
+          dependencies = 100.times.map do
             simple_command(1)
           end
-          command = Expeditor::Command.new(dependencies: commands) do |*vs|
+          Expeditor::Command.new(dependencies: dependencies) do |*vs|
             vs.inject(:+)
           end
         end
@@ -105,7 +105,7 @@ describe Expeditor::Command do
         end
         start = Time.now
         command.start
-        expect(command.get).to eq(90000)
+        expect(command.get).to eq(10000)
       end
     end
 


### PR DESCRIPTION
Since my machine's spec is not so good, running command_functions_spec.rb takes much time.
I think 10000 is large enough to test large number of dependencies.

### before
```
bundle exec rspec spec/expeditor/command_functions_spec.rb:93  96.80s user 5.73s system 103% cpu 1:39.16 total
```

### after
```
bundle exec rspec spec/expeditor/command_functions_spec.rb:93  5.69s user 0.54s system 102% cpu 6.106 total
```