### PR TITLE
Support concurrent-ruby 1.0.0

### DIFF
--- a/expeditor.gemspec
+++ b/expeditor.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "concurrent-ruby", "~> 0.9.0"
-  spec.add_runtime_dependency "concurrent-ruby-ext", "~> 0.9.0"
+  spec.add_runtime_dependency "concurrent-ruby", "~> 1.0.0"
+  spec.add_runtime_dependency "concurrent-ruby-ext", "~> 1.0.0"
   spec.add_runtime_dependency "retryable", "> 1.0"
 
   spec.add_development_dependency "bundler"

--- a/lib/expeditor/rich_future.rb
+++ b/lib/expeditor/rich_future.rb
@@ -26,7 +26,7 @@ module Expeditor
     end
 
     def safe_set(v)
-      set(v) unless completed?
+      set(v) unless complete?
     end
 
     def fail(e)
@@ -34,7 +34,7 @@ module Expeditor
     end
 
     def safe_fail(e)
-      fail(e) unless completed?
+      fail(e) unless complete?
     end
 
     def executed?

--- a/spec/expeditor/rich_future_spec.rb
+++ b/spec/expeditor/rich_future_spec.rb
@@ -67,7 +67,7 @@ describe Expeditor::RichFuture do
       end
       future.execute
       future.set(42)
-      expect(future.completed?).to be true
+      expect(future.complete?).to be true
       expect(future.fulfilled?).to be true
       expect(future.get).to eq(42)
     end
@@ -103,7 +103,7 @@ describe Expeditor::RichFuture do
       end
       future.execute
       future.safe_set(42)
-      expect(future.completed?).to be true
+      expect(future.complete?).to be true
       expect(future.fulfilled?).to be true
       expect(future.get).to eq(42)
     end
@@ -136,7 +136,7 @@ describe Expeditor::RichFuture do
       end
       future.execute
       future.fail(error_in_future.new)
-      expect(future.completed?).to be true
+      expect(future.complete?).to be true
       expect(future.rejected?).to be true
       expect(future.reason).to be_instance_of(error_in_future)
     end
@@ -172,7 +172,7 @@ describe Expeditor::RichFuture do
       end
       future.execute
       future.safe_fail(error_in_future.new)
-      expect(future.completed?).to be true
+      expect(future.complete?).to be true
       expect(future.rejected?).to be true
       expect(future.reason).to be_instance_of(error_in_future)
     end


### PR DESCRIPTION
related to: https://github.com/cookpad/expeditor/pull/2

I fixed expeditor to work with concurrent-ruby v1.0.0.