### PR TITLE
Test against Ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.3.0
   - ruby-head
 matrix:
   allow_failures:


### PR DESCRIPTION
Now, we can't omit ".0" from "2.3.0".