### PR TITLE
Add Expeditor::Service#current_status

### DIFF
--- a/lib/expeditor/service.rb
+++ b/lib/expeditor/service.rb
@@ -66,6 +66,10 @@ module Expeditor
       @executor.shutdown
     end
 
+    def current_status
+      @bucket.current
+    end
+
     private
 
     def calc_open

--- a/spec/expeditor/service_spec.rb
+++ b/spec/expeditor/service_spec.rb
@@ -87,4 +87,18 @@ describe Expeditor::Service do
       expect(command.get).to eq(100)
     end
   end
+
+  describe '#current_status' do
+    let(:service) { Expeditor::Service.new(sleep: 10) }
+    it 'returns current status' do
+      3.times do
+        Expeditor::Command.new(service: service) {
+          raise
+        }.with_fallback { nil }.start.get
+      end
+      status = service.current_status
+      expect(status.success).to eq(0)
+      expect(status.failure).to eq(3)
+    end
+  end
 end


### PR DESCRIPTION
Implement "1. Accessor to the current status in services" of #8 .
`Expeditor::Service#current_status` provides the current status of the status.

@cookpad/dev-infra 👓 ?