### PR TITLE
Add Expeditor::Service#reset_status!

### DIFF
--- a/lib/expeditor/service.rb
+++ b/lib/expeditor/service.rb
@@ -9,11 +9,11 @@ module Expeditor
       @threshold = opts.fetch(:threshold, 0.5) # is 0.5 ok?
       @non_break_count = opts.fetch(:non_break_count, 100) # is 100 ok?
       @sleep = opts.fetch(:sleep, 1)
-      bucket_opts = {
+      @bucket_opts = {
         size: 10,
         per: opts.fetch(:period, 10).to_f / 10
       }
-      @bucket = Expeditor::Bucket.new(bucket_opts)
+      @bucket = Expeditor::Bucket.new(@bucket_opts)
       @breaking = false
       @break_start = nil
     end
@@ -68,6 +68,12 @@ module Expeditor
 
     def current_status
       @bucket.current
+    end
+
+    def reset_status!
+      @bucket = Expeditor::Bucket.new(@bucket_opts)
+      @breaking = false
+      @break_start = nil
     end
 
     private

--- a/lib/expeditor/service.rb
+++ b/lib/expeditor/service.rb
@@ -13,9 +13,7 @@ module Expeditor
         size: 10,
         per: opts.fetch(:period, 10).to_f / 10
       }
-      @bucket = Expeditor::Bucket.new(@bucket_opts)
-      @breaking = false
-      @break_start = nil
+      reset_status!
     end
 
     def success

--- a/spec/expeditor/service_spec.rb
+++ b/spec/expeditor/service_spec.rb
@@ -101,4 +101,17 @@ describe Expeditor::Service do
       expect(status.failure).to eq(3)
     end
   end
+
+  describe '#reset_status!' do
+    let(:service) { Expeditor::Service.new(non_break_count: 1) }
+
+    it "resets the service's status" do
+      2.times do
+        service.failure
+      end
+      expect(service.open?).to be(true)
+      service.reset_status!
+      expect(service.open?).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
Implement "2. Status reset" of #8.
`Expeditor::Service#reset_status!` re-generates the service's bucket and service status is reset.

@cookpad/dev-infra 👓 ?