### PR TITLE
Add Expeditor::Service#fallback_enabled

### DIFF
--- a/lib/expeditor/command.rb
+++ b/lib/expeditor/command.rb
@@ -43,7 +43,7 @@ module Expeditor
     def get
       raise NotStartedError if not started?
       @normal_future.get_or_else do
-        if @fallback_var
+        if @fallback_var && @service.fallback_enabled?
           @fallback_var.wait
           if @fallback_var.rejected?
             raise @fallback_var.reason

--- a/lib/expeditor/command.rb
+++ b/lib/expeditor/command.rb
@@ -65,7 +65,7 @@ module Expeditor
     def wait
       raise NotStartedError if not started?
       @normal_future.wait
-      @fallback_var.wait if @fallback_var
+      @fallback_var.wait if @fallback_var && @service.fallback_enabled?
     end
 
     # command.on_complete do |success, value, reason|

--- a/lib/expeditor/service.rb
+++ b/lib/expeditor/service.rb
@@ -3,6 +3,7 @@ require 'concurrent/executor/thread_pool_executor'
 module Expeditor
   class Service
     attr_reader :executor
+    attr_accessor :fallback_enabled
 
     def initialize(opts = {})
       @executor = opts.fetch(:executor) { Concurrent::ThreadPoolExecutor.new }
@@ -14,6 +15,7 @@ module Expeditor
         per: opts.fetch(:period, 10).to_f / 10
       }
       reset_status!
+      @fallback_enabled = true
     end
 
     def success
@@ -38,6 +40,10 @@ module Expeditor
 
     def dependency
       @bucket.increment :dependency
+    end
+
+    def fallback_enabled?
+      !!fallback_enabled
     end
 
     # break circuit?

--- a/lib/expeditor/services/default.rb
+++ b/lib/expeditor/services/default.rb
@@ -7,6 +7,7 @@ module Expeditor
       def initialize
         @executor = Concurrent.global_io_executor
         @bucket = nil
+        @fallback_enabled = true
       end
 
       def success

--- a/spec/expeditor/service_spec.rb
+++ b/spec/expeditor/service_spec.rb
@@ -114,4 +114,37 @@ describe Expeditor::Service do
       expect(service.open?).to be(false)
     end
   end
+
+  describe '#fallback_enabled' do
+    let(:service) { Expeditor::Service.new(sleep: 10) }
+
+    context 'fallback_enabled is true' do
+      before do
+        service.fallback_enabled = true
+      end
+
+      it 'returns fallback value' do
+        result = Expeditor::Command.new(service: service) {
+          raise 'error!'
+        }.with_fallback {
+          0
+        }.start.get
+        expect(result).to eq(0)
+      end
+    end
+
+    context 'fallback_enabled is false' do
+      before do
+        service.fallback_enabled = false
+      end
+
+      it 'does not call fallback and raises error' do
+        expect { Expeditor::Command.new(service: service) {
+          raise 'error!'
+        }.with_fallback {
+          0
+        }.start.get }.to raise_error(RuntimeError, 'error!')
+      end
+    end
+  end
 end

--- a/spec/expeditor/service_spec.rb
+++ b/spec/expeditor/service_spec.rb
@@ -139,11 +139,13 @@ describe Expeditor::Service do
       end
 
       it 'does not call fallback and raises error' do
-        expect { Expeditor::Command.new(service: service) {
-          raise 'error!'
-        }.with_fallback {
-          0
-        }.start.get }.to raise_error(RuntimeError, 'error!')
+        expect {
+          Expeditor::Command.new(service: service) {
+            raise 'error!'
+          }.with_fallback {
+            0
+          }.start.get
+        }.to raise_error(RuntimeError, 'error!')
       end
     end
   end


### PR DESCRIPTION
Implement "3. Fallbackable flag" of #8. ("Fallbackable is renamed to "fallback_enabled")
It provides "enabling and disabling" fallback blocks in the command.

@cookpad/dev-infra 👓 ?