### PR TITLE
Execute a command on current thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Master (unreleased)
 
-- Add `Command#run` method to execute a task on current thread [#13](https://github.com/cookpad/expeditor/pull/13)
+- Add a `current_thread` option of `Expeditor::Command#start` method to execute a task on current thread [#13](https://github.com/cookpad/expeditor/pull/13)
 - Drop support for MRI 2.0.x [#15](https://github.com/cookpad/expeditor/pull/15)
 - Deprecate Expeditor::Command#with_fallback. Use `set_fallback` instead [#14](https://github.com/cookpad/expeditor/pull/14)
 - Do not allow set_fallback call after command is started. [#18](https://github.com/cookpad/expeditor/pull/18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Master (unreleased)
 
+- Add `Command#run` method to execute a task on current thread [#13](https://github.com/cookpad/expeditor/pull/13)
 - Drop support for MRI 2.0.x [#15](https://github.com/cookpad/expeditor/pull/15)
 - Deprecate Expeditor::Command#with_fallback. Use `set_fallback` instead [#14](https://github.com/cookpad/expeditor/pull/14)
 - Do not allow set_fallback call after command is started. [#18](https://github.com/cookpad/expeditor/pull/18)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ end
 
 ### synchronous execution
 
-Use `Expeditor::Command#run` instead of `#start`, Command executes synchronous on current thread.
+Use `current_thread` option of `#start`, command executes synchronous on current thread.
 
 ```ruby
 command1 = Expeditor::Command.new do
@@ -160,8 +160,8 @@ command2 = Expeditor::Command.new do
   ...
 end
 
-command1.run # blocking
-command2.run # blocking
+command1.start(current_thread: true) # blocking
+command2.start(current_thread: true) # blocking
 
 command1.get
 command2.get

--- a/README.md
+++ b/README.md
@@ -147,6 +147,26 @@ command = Expeditor::Command.new(service: service) do
 end
 ```
 
+### synchronous execution
+
+Use `Expeditor::Command#run` instead of `#start`, Command executes synchronous on current thread.
+
+```ruby
+command1 = Expeditor::Command.new do
+  ...
+end
+
+command2 = Expeditor::Command.new do
+  ...
+end
+
+command1.run # blocking
+command2.run # blocking
+
+command1.get
+command2.get
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/expeditor/command.rb
+++ b/lib/expeditor/command.rb
@@ -14,14 +14,26 @@ module Expeditor
       @service = opts.fetch(:service, Expeditor::Services.default)
       @timeout = opts[:timeout]
       @dependencies = opts.fetch(:dependencies, [])
-      @normal_future = initial_normal(&block)
-      @fallback_var = nil
+
+      @normal_future = nil
       @retryable_options = Concurrent::IVar.new
+      @normal_block = block
+      @fallback_block = nil
+      @ivar = Concurrent::IVar.new
     end
 
     def start
       if not started?
-        @dependencies.each(&:start)
+        prepare
+        @normal_future.safe_execute
+      end
+      self
+    end
+
+    # run is similar to the `start`, but the method is executed on the current thread.
+    def run
+      if not started?
+        prepare(Concurrent::ImmediateExecutor.new)
         @normal_future.safe_execute
       end
       self
@@ -37,18 +49,18 @@ module Expeditor
     end
 
     def started?
-      @normal_future.executed?
+      !!@normal_future && @normal_future.executed?
     end
 
     def get
       raise NotStartedError if not started?
       @normal_future.get_or_else do
-        if @fallback_var && @service.fallback_enabled?
-          @fallback_var.wait
-          if @fallback_var.rejected?
-            raise @fallback_var.reason
+        if @fallback_block && @service.fallback_enabled?
+          @ivar.wait
+          if @ivar.rejected?
+            raise @ivar.reason
           else
-            @fallback_var.value
+            @ivar.value
           end
         else
           raise @normal_future.reason
@@ -71,8 +83,7 @@ module Expeditor
 
     def wait
       raise NotStartedError if not started?
-      @normal_future.wait
-      @fallback_var.wait if @fallback_var && @service.fallback_enabled?
+      @ivar.wait
     end
 
     # command.on_complete do |success, value, reason|
@@ -119,18 +130,7 @@ module Expeditor
     private
 
     def reset_fallback(&block)
-      @fallback_var = Concurrent::IVar.new
-      @normal_future.add_observer do |_, value, reason|
-        if reason != nil
-          future = RichFuture.new(executor: Concurrent.global_io_executor) do
-            success, val, reason = Concurrent::SafeTaskExecutor.new(block, rescue_exception: true).execute(reason)
-            @fallback_var.send(:complete, success, val, reason)
-          end
-          future.safe_execute
-        else
-          @fallback_var.send(:complete, true, value, nil)
-        end
-      end
+      @fallback_block = block
     end
 
     def breakable_block(args, &block)
@@ -186,8 +186,8 @@ module Expeditor
     #     end
     #   end
     # end
-    def initial_normal(&block)
-      future = RichFuture.new(executor: @service.executor) do
+    def initial_normal(executor, &block)
+      future = RichFuture.new(executor: executor) do
         args = wait_dependencies
         timeout_block(args, &block)
       end
@@ -229,18 +229,37 @@ module Expeditor
     end
 
     def on(&callback)
-      if @fallback_var
-        @fallback_var.add_observer(&callback)
-      else
-        @normal_future.add_observer(&callback)
+      @ivar.add_observer(&callback)
+    end
+
+    # set future
+    # set fallback future as an observer
+    # start dependencies
+    def prepare(executor = @service.executor)
+      @normal_future = initial_normal(executor, &@normal_block)
+      @normal_future.add_observer do |_, value, reason|
+        if reason # failure
+          if @fallback_block
+            future = RichFuture.new(executor: executor) do
+              success, value, reason = Concurrent::SafeTaskExecutor.new(@fallback_block, rescue_exception: true).execute(reason)
+              @ivar.send(:complete, success, value, reason)
+            end
+            future.safe_execute
+          else
+            @ivar.fail(reason)
+          end
+        else # success
+          @ivar.set(value)
+        end
       end
+
+      @dependencies.each(&:start)
     end
 
     class ConstCommand < Command
       def initialize(value)
-        @service = Expeditor::Services.default
-        @dependencies = []
-        @normal_future = RichFuture.new {}.set(value)
+        super(){ value }
+        self.start
       end
     end
   end

--- a/lib/expeditor/command.rb
+++ b/lib/expeditor/command.rb
@@ -24,7 +24,7 @@ module Expeditor
 
     # @param current_thread [Boolean] Execute the task on current thread(blocking)
     def start(current_thread: false)
-      if not started?
+      unless started?
         if current_thread
           prepare(Concurrent::ImmediateExecutor.new)
         else
@@ -37,7 +37,7 @@ module Expeditor
 
     # Equivalent to retryable gem options
     def start_with_retry(retryable_options = {})
-      if not started?
+      unless started?
         @retryable_options.set(retryable_options)
         start
       end
@@ -49,7 +49,7 @@ module Expeditor
     end
 
     def get
-      raise NotStartedError if not started?
+      raise NotStartedError unless started?
       @normal_future.get_or_else do
         if @fallback_block && @service.fallback_enabled?
           @ivar.wait
@@ -78,7 +78,7 @@ module Expeditor
     end
 
     def wait
-      raise NotStartedError if not started?
+      raise NotStartedError unless started?
       @ivar.wait
     end
 

--- a/lib/expeditor/command.rb
+++ b/lib/expeditor/command.rb
@@ -36,9 +36,8 @@ module Expeditor
     end
 
     # Equivalent to retryable gem options
-    def start_with_retry(retryable_options = {})
+    def start_with_retry(current_thread: false, **retryable_options)
       unless started?
-        current_thread = retryable_options.delete(:current_thread)
         @retryable_options.set(retryable_options)
         start(current_thread: current_thread)
       end
@@ -46,7 +45,7 @@ module Expeditor
     end
 
     def started?
-      !!@normal_future && @normal_future.executed?
+      @normal_future && @normal_future.executed?
     end
 
     def get

--- a/lib/expeditor/command.rb
+++ b/lib/expeditor/command.rb
@@ -22,18 +22,14 @@ module Expeditor
       @ivar = Concurrent::IVar.new
     end
 
-    def start
+    # @param current_thread [Boolean] Execute the task on current thread(blocking)
+    def start(current_thread: false)
       if not started?
-        prepare
-        @normal_future.safe_execute
-      end
-      self
-    end
-
-    # run is similar to the `start`, but the method is executed on the current thread.
-    def run
-      if not started?
-        prepare(Concurrent::ImmediateExecutor.new)
+        if current_thread
+          prepare(Concurrent::ImmediateExecutor.new)
+        else
+          prepare
+        end
         @normal_future.safe_execute
       end
       self

--- a/lib/expeditor/command.rb
+++ b/lib/expeditor/command.rb
@@ -38,8 +38,9 @@ module Expeditor
     # Equivalent to retryable gem options
     def start_with_retry(retryable_options = {})
       unless started?
+        current_thread = retryable_options.delete(:current_thread)
         @retryable_options.set(retryable_options)
-        start
+        start(current_thread: current_thread)
       end
       self
     end

--- a/spec/expeditor/command_functions_spec.rb
+++ b/spec/expeditor/command_functions_spec.rb
@@ -133,7 +133,7 @@ describe Expeditor::Command do
     context 'with large number of commands' do
       it 'should not throw any errors' do
         service = Expeditor::Service.new(executor: Concurrent::ThreadPoolExecutor.new(max_threads: 10, min_threads: 10, max_queue: 100))
-        commands = 1000.times.map do
+        commands = 100.times.map do
           Expeditor::Command.new(service: service) do
             raise error_in_command
           end.set_fallback do |e|
@@ -142,7 +142,7 @@ describe Expeditor::Command do
         end
         commands.each(&:start)
         sum = commands.map(&:get).inject(:+)
-        expect(sum).to eq(1000)
+        expect(sum).to eq(100)
         service.shutdown
       end
     end

--- a/spec/expeditor/command_spec.rb
+++ b/spec/expeditor/command_spec.rb
@@ -91,9 +91,9 @@ describe Expeditor::Command do
     end
 
     context 'with not started' do
-      it 'should be false' do
+      it 'should be falsy' do
         command = simple_command(42)
-        expect(command.started?).to be false
+        expect(command.started?).to be_falsy
       end
     end
 
@@ -101,8 +101,8 @@ describe Expeditor::Command do
       it 'should be true (both) if the command with no fallback is started' do
         command = simple_command(42)
         fallback_command = command.set_fallback { 0 }
-        expect(command.started?).to be false
-        expect(fallback_command.started?).to be false
+        expect(command.started?).to be_falsy
+        expect(fallback_command.started?).to be_falsy
         command.start
         expect(command.started?).to be true
         expect(fallback_command.started?).to be true
@@ -111,8 +111,8 @@ describe Expeditor::Command do
       it 'should be true (both) if the command with fallback is started' do
         command = simple_command(42)
         fallback_command = command.set_fallback { 0 }
-        expect(command.started?).to be false
-        expect(fallback_command.started?).to be false
+        expect(command.started?).to be_falsy
+        expect(fallback_command.started?).to be_falsy
         fallback_command.start
         expect(command.started?).to be true
         expect(fallback_command.started?).to be true

--- a/spec/expeditor/command_spec.rb
+++ b/spec/expeditor/command_spec.rb
@@ -81,6 +81,65 @@ describe Expeditor::Command do
     end
   end
 
+  describe '#run' do
+    context 'with normal' do
+      it 'should run on current thread' do
+        Thread.current.thread_variable_set('foo', 'bar')
+        command = Expeditor::Command.new do
+          Thread.current.thread_variable_get('foo')
+        end
+        expect(command.run.get).to eq('bar')
+      end
+
+      it 'should return self' do
+        command = simple_command(42)
+        expect(command.run).to eq(command)
+      end
+
+      it 'should ignore from the second time' do
+        count = 0
+        command = Expeditor::Command.new do
+          count += 1
+          count
+        end
+        command.run
+        command.run
+        command.run
+        expect(command.get).to eq(1)
+        expect(count).to eq(1)
+      end
+    end
+
+    context 'with fallback' do
+      it 'should work fallback proc' do
+        command = error_command(error_in_command, nil)
+        command.set_fallback do
+          42
+        end
+
+        expect(command.run.get).to eq(42)
+      end
+
+      it 'should work fallback on current thread' do
+        Thread.current.thread_variable_set("count", 1)
+        command = Expeditor::Command.new do
+          count = Thread.current.thread_variable_get("count")
+          count += 1
+          Thread.current.thread_variable_set("count", count) # => 2
+          raise error_in_command
+        end
+
+        command.set_fallback do
+          count = Thread.current.thread_variable_get("count")
+          count += 1
+          count # => 3
+        end
+
+        expect(command.run.get).to eq(3)
+      end
+    end
+  end
+
   describe '#started?' do
     context 'with started' do
       it 'should be true' do

--- a/spec/expeditor/command_spec.rb
+++ b/spec/expeditor/command_spec.rb
@@ -79,65 +79,6 @@ describe Expeditor::Command do
         expect(command.get).to eq(1000)
       end
     end
-
-    context 'current thread mode' do
-      context 'with normal' do
-        it 'should execute on current thread' do
-          Thread.current.thread_variable_set('foo', 'bar')
-          command = Expeditor::Command.new do
-            Thread.current.thread_variable_get('foo')
-          end
-          expect(command.start(current_thread: true).get).to eq('bar')
-        end
-
-        it 'should return self' do
-          command = simple_command(42)
-          expect(command.start(current_thread: true)).to eq(command)
-        end
-
-        it 'should ignore from the second time' do
-          count = 0
-          command = Expeditor::Command.new do
-            count += 1
-            count
-          end
-          command.start(current_thread: true)
-          command.start(current_thread: true)
-          command.start(current_thread: true)
-          expect(command.get).to eq(1)
-          expect(count).to eq(1)
-        end
-      end
-
-      context 'with fallback' do
-        it 'should work fallback proc' do
-          command = error_command(error_in_command, nil)
-          command.set_fallback do
-            42
-          end
-
-          expect(command.start(current_thread: true).get).to eq(42)
-        end
-
-        it 'should work fallback on current thread' do
-          Thread.current.thread_variable_set("count", 1)
-          command = Expeditor::Command.new do
-            count = Thread.current.thread_variable_get("count")
-            count += 1
-            Thread.current.thread_variable_set("count", count) # => 2
-            raise error_in_command
-          end
-
-          command.set_fallback do
-            count = Thread.current.thread_variable_get("count")
-            count += 1
-            count # => 3
-          end
-
-          expect(command.start(current_thread: true).get).to eq(3)
-        end
-      end
-    end
   end
 
   describe '#started?' do

--- a/spec/expeditor/command_spec.rb
+++ b/spec/expeditor/command_spec.rb
@@ -79,63 +79,63 @@ describe Expeditor::Command do
         expect(command.get).to eq(1000)
       end
     end
-  end
 
-  describe '#run' do
-    context 'with normal' do
-      it 'should run on current thread' do
-        Thread.current.thread_variable_set('foo', 'bar')
-        command = Expeditor::Command.new do
-          Thread.current.thread_variable_get('foo')
+    context 'current thread mode' do
+      context 'with normal' do
+        it 'should execute on current thread' do
+          Thread.current.thread_variable_set('foo', 'bar')
+          command = Expeditor::Command.new do
+            Thread.current.thread_variable_get('foo')
+          end
+          expect(command.start(current_thread: true).get).to eq('bar')
         end
-        expect(command.run.get).to eq('bar')
+
+        it 'should return self' do
+          command = simple_command(42)
+          expect(command.start(current_thread: true)).to eq(command)
+        end
+
+        it 'should ignore from the second time' do
+          count = 0
+          command = Expeditor::Command.new do
+            count += 1
+            count
+          end
+          command.start(current_thread: true)
+          command.start(current_thread: true)
+          command.start(current_thread: true)
+          expect(command.get).to eq(1)
+          expect(count).to eq(1)
+        end
       end
 
-      it 'should return self' do
-        command = simple_command(42)
-        expect(command.run).to eq(command)
-      end
+      context 'with fallback' do
+        it 'should work fallback proc' do
+          command = error_command(error_in_command, nil)
+          command.set_fallback do
+            42
+          end
 
-      it 'should ignore from the second time' do
-        count = 0
-        command = Expeditor::Command.new do
-          count += 1
-          count
-        end
-        command.run
-        command.run
-        command.run
-        expect(command.get).to eq(1)
-        expect(count).to eq(1)
-      end
-    end
-
-    context 'with fallback' do
-      it 'should work fallback proc' do
-        command = error_command(error_in_command, nil)
-        command.set_fallback do
-          42
+          expect(command.start(current_thread: true).get).to eq(42)
         end
 
-        expect(command.run.get).to eq(42)
-      end
+        it 'should work fallback on current thread' do
+          Thread.current.thread_variable_set("count", 1)
+          command = Expeditor::Command.new do
+            count = Thread.current.thread_variable_get("count")
+            count += 1
+            Thread.current.thread_variable_set("count", count) # => 2
+            raise error_in_command
+          end
 
-      it 'should work fallback on current thread' do
-        Thread.current.thread_variable_set("count", 1)
-        command = Expeditor::Command.new do
-          count = Thread.current.thread_variable_get("count")
-          count += 1
-          Thread.current.thread_variable_set("count", count) # => 2
-          raise error_in_command
+          command.set_fallback do
+            count = Thread.current.thread_variable_get("count")
+            count += 1
+            count # => 3
+          end
+
+          expect(command.start(current_thread: true).get).to eq(3)
         end
-
-        command.set_fallback do
-          count = Thread.current.thread_variable_get("count")
-          count += 1
-          count # => 3
-        end
-
-        expect(command.run.get).to eq(3)
       end
     end
   end

--- a/spec/expeditor/current_thread_function_spec.rb
+++ b/spec/expeditor/current_thread_function_spec.rb
@@ -5,7 +5,7 @@ describe Expeditor::Command do
 
   describe '#start' do
     context 'with normal' do
-      it 'should execute on current thread' do
+      it 'executes on current thread' do
         Thread.current.thread_variable_set('foo', 'bar')
         command = Expeditor::Command.new do
           Thread.current.thread_variable_get('foo')
@@ -13,12 +13,12 @@ describe Expeditor::Command do
         expect(command.start(current_thread: true).get).to eq('bar')
       end
 
-      it 'should return self' do
+      it 'returns self' do
         command = simple_command(42)
         expect(command.start(current_thread: true)).to eq(command)
       end
 
-      it 'should ignore from the second time' do
+      it 'ignores from the second time' do
         count = 0
         command = Expeditor::Command.new do
           count += 1
@@ -33,7 +33,7 @@ describe Expeditor::Command do
     end
 
     context 'with fallback' do
-      it 'should work fallback proc' do
+      it 'works fallback proc' do
         command = error_command(error_in_command)
         command.set_fallback do
           42
@@ -42,7 +42,7 @@ describe Expeditor::Command do
         expect(command.start(current_thread: true).get).to eq(42)
       end
 
-      it 'should work fallback on current thread' do
+      it 'works fallback on current thread' do
         Thread.current.thread_variable_set("count", 1)
         command = Expeditor::Command.new do
           count = Thread.current.thread_variable_get("count")
@@ -62,14 +62,14 @@ describe Expeditor::Command do
     end
 
     context 'explicitly specify `current_thread: false`' do
-      it 'should be asynchronous' do
+      it 'is asynchronous' do
         command = sleep_command(0.2, nil)
         start_time = Time.now
         command.start(current_thread: false)
         expect(Time.now - start_time).to be < 0.2
       end
 
-      it 'should not execute on current thread' do
+      it 'does not execute on current thread' do
         Thread.current.thread_variable_set('foo', 1)
         command = Expeditor::Command.new do
           Thread.current.thread_variable_get('foo')
@@ -82,7 +82,7 @@ describe Expeditor::Command do
 
   describe '#start_with_retry' do
     context 'with 3 tries' do
-      it 'should execute 3 times on current thread' do
+      it 'executes 3 times on current thread' do
         Thread.current.thread_variable_set('count', 0)
         command = Expeditor::Command.new do
           count = Thread.current.thread_variable_get('count')
@@ -97,14 +97,14 @@ describe Expeditor::Command do
     end
 
     context 'explicitly specify `current_thread: false`' do
-      it 'should be asynchronous' do
+      it 'is asynchronous' do
         command = sleep_command(0.2, nil)
         start_time = Time.now
         command.start_with_retry(current_thread: false)
         expect(Time.now - start_time).to be < 0.2
       end
 
-      it 'should not execute on current thread' do
+      it 'does not execute on current thread' do
         Thread.current.thread_variable_set('foo', 1)
         command = Expeditor::Command.new do
           Thread.current.thread_variable_get('foo')

--- a/spec/expeditor/current_thread_function_spec.rb
+++ b/spec/expeditor/current_thread_function_spec.rb
@@ -1,0 +1,117 @@
+require 'spec_helper'
+
+describe Expeditor::Command do
+  let(:error_in_command) { Class.new(StandardError) }
+
+  describe '#start' do
+    context 'with normal' do
+      it 'should execute on current thread' do
+        Thread.current.thread_variable_set('foo', 'bar')
+        command = Expeditor::Command.new do
+          Thread.current.thread_variable_get('foo')
+        end
+        expect(command.start(current_thread: true).get).to eq('bar')
+      end
+
+      it 'should return self' do
+        command = simple_command(42)
+        expect(command.start(current_thread: true)).to eq(command)
+      end
+
+      it 'should ignore from the second time' do
+        count = 0
+        command = Expeditor::Command.new do
+          count += 1
+          count
+        end
+        command.start(current_thread: true)
+        command.start(current_thread: true)
+        command.start(current_thread: true)
+        expect(command.get).to eq(1)
+        expect(count).to eq(1)
+      end
+    end
+
+    context 'with fallback' do
+      it 'should work fallback proc' do
+        command = error_command(error_in_command)
+        command.set_fallback do
+          42
+        end
+
+        expect(command.start(current_thread: true).get).to eq(42)
+      end
+
+      it 'should work fallback on current thread' do
+        Thread.current.thread_variable_set("count", 1)
+        command = Expeditor::Command.new do
+          count = Thread.current.thread_variable_get("count")
+          count += 1
+          Thread.current.thread_variable_set("count", count) # => 2
+          raise error_in_command
+        end
+
+        command.set_fallback do
+          count = Thread.current.thread_variable_get("count")
+          count += 1
+          count # => 3
+        end
+
+        expect(command.start(current_thread: true).get).to eq(3)
+      end
+    end
+
+    context 'explicitly specify `current_thread: false`' do
+      it 'should be asynchronous' do
+        command = sleep_command(0.2, nil)
+        start_time = Time.now
+        command.start(current_thread: false)
+        expect(Time.now - start_time).to be < 0.2
+      end
+
+      it 'should not execute on current thread' do
+        Thread.current.thread_variable_set('foo', 1)
+        command = Expeditor::Command.new do
+          Thread.current.thread_variable_get('foo')
+        end
+        command.start(current_thread: false)
+        expect(command.get).to eq nil
+      end
+    end
+  end
+
+  describe '#start_with_retry' do
+    context 'with 3 tries' do
+      it 'should execute 3 times on current thread' do
+        Thread.current.thread_variable_set('count', 0)
+        command = Expeditor::Command.new do
+          count = Thread.current.thread_variable_get('count')
+          count += 1
+          Thread.current.thread_variable_set('count', count)
+          raise RuntimeError
+        end
+        command.start_with_retry(tries: 3, sleep: 0, current_thread: true)
+        expect { command.get }.to raise_error(RuntimeError)
+        expect(Thread.current.thread_variable_get('count')).to eq 3
+      end
+    end
+
+    context 'explicitly specify `current_thread: false`' do
+      it 'should be asynchronous' do
+        command = sleep_command(0.2, nil)
+        start_time = Time.now
+        command.start_with_retry(current_thread: false)
+        expect(Time.now - start_time).to be < 0.2
+      end
+
+      it 'should not execute on current thread' do
+        Thread.current.thread_variable_set('foo', 1)
+        command = Expeditor::Command.new do
+          Thread.current.thread_variable_get('foo')
+        end
+        command.start_with_retry(current_thread: false)
+        expect(command.get).to eq nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
I've added a feature to execute a command on current thread.

Currently, we can execute a command on current thread by the following code.

```ruby
require 'expeditor'
require 'concurrent/executor/immediate_executor'

service = Expeditor::Service.new executor: Concurrent::ImmediateExecutor.new
command = Expeditor::Command.new(service: service){puts 1; sleep 1; puts 2}

puts 'start'
command.start
puts 'end'
```

However, it's complexity. So, I've added `Command#run` method to execute on current thread.
The following code works same as the above.

```ruby
service = Expeditor::Service.new
command = Expeditor::Command.new(service: service){puts 1; sleep 1; puts 2}

puts 'start'
command.run  # use run instead of start
puts 'end'
```

Naming of `run` is inspired by `exec.Command` of Golang. https://golang.org/pkg/os/exec/#Cmd.Run