### PR TITLE
Don't clone when `with_fallback` is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Master (unreleased)
+
+- Deprecate Expeditor::Command#with_fallback. Use `set_fallback` instead [#14](https://github.com/cookpad/expeditor/issues/9)
+
 ## 0.4.0
 - Add Expeditor::Service#current\_status [#9](https://github.com/cookpad/expeditor/issues/9)
 - Add Expeditor::Service#reset\_status! [#10](https://github.com/cookpad/expeditor/issues/10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Master (unreleased)
 
-- Deprecate Expeditor::Command#with_fallback. Use `set_fallback` instead [#14](https://github.com/cookpad/expeditor/issues/9)
+- Deprecate Expeditor::Command#with_fallback. Use `set_fallback` instead [#14](https://github.com/cookpad/expeditor/pull/14)
 
 ## 0.4.0
 - Add Expeditor::Service#current\_status [#9](https://github.com/cookpad/expeditor/issues/9)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ command = Expeditor::Command.new do
 end
 
 # use fallback value if command is failed
-command_with_fallback = command.with_fallback do |e|
+command_with_fallback = command.set_fallback do |e|
   log(e)
   default_value
 end

--- a/examples/example.rb
+++ b/examples/example.rb
@@ -24,7 +24,7 @@ command2 = Expeditor::Command.new(service: service, timeout: 0.5) do
   'command2'
 end
 # command2_d is command2 with fallback
-command2_d = command2.with_fallback do |e|
+command2_d = command2.set_fallback do |e|
   'command2 fallback'
 end
 
@@ -44,7 +44,7 @@ command4 = Expeditor::Command.new(
   sleep 0.3
   v2 + ', ' + v3
 end
-command4_d = command4.with_fallback do
+command4_d = command4.set_fallback do
   'command4 fallback'
 end
 

--- a/lib/expeditor/command.rb
+++ b/lib/expeditor/command.rb
@@ -56,9 +56,14 @@ module Expeditor
       end
     end
 
-    def with_fallback(&block)
+    def set_fallback(&block)
       reset_fallback(&block)
       self
+    end
+
+    def with_fallback(&block)
+      warn 'Expeditor::Command#with_fallback is deprecated. Please use set_fallback instead'
+      set_fallback(&block)
     end
 
     def wait

--- a/lib/expeditor/command.rb
+++ b/lib/expeditor/command.rb
@@ -57,9 +57,8 @@ module Expeditor
     end
 
     def with_fallback(&block)
-      command = self.clone
-      command.reset_fallback(&block)
-      command
+      reset_fallback(&block)
+      self
     end
 
     def wait
@@ -109,7 +108,7 @@ module Expeditor
       Command.new(opts, &block).start
     end
 
-    protected
+    private
 
     def reset_fallback(&block)
       @fallback_var = Concurrent::IVar.new
@@ -125,8 +124,6 @@ module Expeditor
         end
       end
     end
-
-    private
 
     def breakable_block(args, &block)
       if @service.open?

--- a/spec/expeditor/circuit_break_function_spec.rb
+++ b/spec/expeditor/circuit_break_function_spec.rb
@@ -8,7 +8,7 @@ describe Expeditor::Command do
         commands = 100.times.map do
           Expeditor::Command.new(service: service) do
             raise RuntimeError
-          end.with_fallback do |e|
+          end.set_fallback do |e|
             if e === Expeditor::CircuitBreakError
               1
             else
@@ -94,7 +94,7 @@ describe Expeditor::Command do
         failure_commands = 2000.times.map do
           Expeditor::Command.start(service: service) do
             raise RuntimeError
-          end.with_fallback do
+          end.set_fallback do
             1
           end
         end
@@ -109,7 +109,7 @@ describe Expeditor::Command do
           dependencies: failure_commands + success_commands,
         ) do |*vs|
           vs.inject(:+)
-        end.with_fallback do |e|
+        end.set_fallback do |e|
           reason = e
           0
         end
@@ -131,7 +131,7 @@ describe Expeditor::Command do
         failure_commands = 20.times.map do
           Expeditor::Command.new(service: service) do
             raise RuntimeError
-          end.with_fallback do
+          end.set_fallback do
             1
           end
         end
@@ -145,7 +145,7 @@ describe Expeditor::Command do
           dependencies: failure_commands + success_commands,
         ) do |*vs|
           vs.inject(:+)
-        end.with_fallback do |e|
+        end.set_fallback do |e|
           0
         end
         command.start

--- a/spec/expeditor/command_functions_spec.rb
+++ b/spec/expeditor/command_functions_spec.rb
@@ -173,7 +173,6 @@ describe Expeditor::Command do
   describe 'entire' do
     context 'with complex example' do
       it 'should be ok' do
-        start = Time.now
         command1 = sleep_command(0.1, 1)
         command2 = sleep_command(1000, 'timeout!', timeout: 0.5)
         fallback_command2 = command2.with_fallback do |e|
@@ -191,16 +190,22 @@ describe Expeditor::Command do
           8
         end
 
+        start = Time.now
         fallback_command4.start
 
+        # command is same as fallback command.
+        expect(command2).to eq fallback_command2
+        expect(command4).to eq fallback_command4
+
         expect(command1.get).to eq(1)
-        expect(fallback_command4.get).to eq(8)
-        expect(Time.now - start).to be < 0.52
+        expect(Time.now - start).to be < 0.12
+        expect(fallback_command4.get).to eq(17)
+        expect(Time.now - start).to be < 1.12
 
         expect(command1.get).to eq(1)
         expect(fallback_command2.get).to eq(2)
         expect(command3.get).to eq(7)
-        expect(Time.now - start).to be < 0.72
+        expect(Time.now - start).to be < 1.12
       end
     end
   end

--- a/spec/expeditor/command_functions_spec.rb
+++ b/spec/expeditor/command_functions_spec.rb
@@ -126,7 +126,7 @@ describe Expeditor::Command do
   describe 'fallback function' do
     context 'with normal' do
       it 'should be normal value' do
-        command = simple_command(42).with_fallback { 0 }
+        command = simple_command(42).set_fallback { 0 }
         command.start
         expect(command.get).to eq(42)
       end
@@ -134,7 +134,7 @@ describe Expeditor::Command do
 
     context 'with failure of normal' do
       it 'should be fallback value' do
-        command = error_command(error_in_command, 42).with_fallback { 0 }
+        command = error_command(error_in_command, 42).set_fallback { 0 }
         command.start
         expect(command.get).to eq(0)
       end
@@ -144,7 +144,7 @@ describe Expeditor::Command do
       let(:error_in_fallback) { Class.new(Exception) }
 
       it 'should throw fallback error' do
-        command = error_command(error_in_command, 42).with_fallback do
+        command = error_command(error_in_command, 42).set_fallback do
           raise error_in_fallback
         end
         command.start
@@ -158,7 +158,7 @@ describe Expeditor::Command do
         commands = 1000.times.map do
           Expeditor::Command.new(service: service) do
             raise error_in_command
-          end.with_fallback do |e|
+          end.set_fallback do |e|
             1
           end
         end
@@ -175,7 +175,7 @@ describe Expeditor::Command do
       it 'should be ok' do
         command1 = sleep_command(0.1, 1)
         command2 = sleep_command(1000, 'timeout!', timeout: 0.5)
-        fallback_command2 = command2.with_fallback do |e|
+        fallback_command2 = command2.set_fallback do |e|
           2
         end
         command3 = Expeditor::Command.new(dependencies: [command1, fallback_command2]) do |v1, v2|
@@ -186,7 +186,7 @@ describe Expeditor::Command do
           sleep 0.3
           v2 + v3 + 8
         end
-        fallback_command4 = command4.with_fallback do
+        fallback_command4 = command4.set_fallback do
           8
         end
 

--- a/spec/expeditor/command_spec.rb
+++ b/spec/expeditor/command_spec.rb
@@ -86,7 +86,7 @@ describe Expeditor::Command do
         commands = 1000.times.map do
           Expeditor::Command.start(service: service) do
             raise error_in_command
-          end.with_fallback do
+          end.set_fallback do
             1
           end
         end
@@ -120,7 +120,7 @@ describe Expeditor::Command do
     context 'with fallback' do
       it 'should be true (both) if the command with no fallback is started' do
         command = simple_command(42)
-        fallback_command = command.with_fallback { 0 }
+        fallback_command = command.set_fallback { 0 }
         expect(command.started?).to be false
         expect(fallback_command.started?).to be false
         command.start
@@ -130,7 +130,7 @@ describe Expeditor::Command do
 
       it 'should be true (both) if the command with fallback is started' do
         command = simple_command(42)
-        fallback_command = command.with_fallback { 0 }
+        fallback_command = command.set_fallback { 0 }
         expect(command.started?).to be false
         expect(fallback_command.started?).to be false
         fallback_command.start
@@ -192,10 +192,10 @@ describe Expeditor::Command do
     end
   end
 
-  describe '#with_fallback' do
+  describe '#set_fallback' do
     it 'should return new command and same normal_future' do
       command = simple_command(42)
-      fallback_command = command.with_fallback do
+      fallback_command = command.set_fallback do
         0
       end
       expect(fallback_command).to eq(command)
@@ -207,7 +207,7 @@ describe Expeditor::Command do
       command.start
       command.wait
       start_time = Time.now
-      fallback_command = command.with_fallback do
+      fallback_command = command.set_fallback do
         sleep 0.1
         0
       end
@@ -217,7 +217,7 @@ describe Expeditor::Command do
 
     context 'with normal success' do
       it 'should return normal result' do
-        command = simple_command(42).with_fallback { 0 }
+        command = simple_command(42).set_fallback { 0 }
         command.start
         expect(command.get).to eq(42)
       end
@@ -241,7 +241,7 @@ describe Expeditor::Command do
         command = Expeditor::Command.new {
           sleep 0.1
           raise error_in_command
-        }.with_fallback {
+        }.set_fallback {
           sleep 0.1
           42
         }
@@ -253,7 +253,7 @@ describe Expeditor::Command do
     context 'with fallback but normal success' do
       it 'should not wait fallback execution' do
         start_time = Time.now
-        command = simple_command(42).with_fallback do
+        command = simple_command(42).set_fallback do
           sleep 0.1
           0
         end
@@ -293,7 +293,7 @@ describe Expeditor::Command do
 
     context 'with normal success and with fallback' do
       it 'should run callback with success' do
-        command = simple_command(42).with_fallback { 0 }
+        command = simple_command(42).set_fallback { 0 }
         success = nil
         value = nil
         reason = nil
@@ -329,7 +329,7 @@ describe Expeditor::Command do
 
     context 'with normal failure and with fallback success' do
       it 'should run callback with success' do
-        command = error_command(error_in_command, 42).with_fallback { 0 }
+        command = error_command(error_in_command, 42).set_fallback { 0 }
         success = nil
         value = nil
         reason = nil
@@ -347,7 +347,7 @@ describe Expeditor::Command do
 
     context 'with normal failure and with fallback failure' do
       it 'should run callback with failure' do
-        command = error_command(error_in_command, 42).with_fallback do |e|
+        command = error_command(error_in_command, 42).set_fallback do |e|
           raise e
         end
         success = nil
@@ -381,7 +381,7 @@ describe Expeditor::Command do
 
     context 'with normal success and with fallback' do
       it 'should run callback' do
-        command = simple_command(42).with_fallback { 0 }
+        command = simple_command(42).set_fallback { 0 }
         res = nil
         command.on_success do |v|
           res = v
@@ -405,7 +405,7 @@ describe Expeditor::Command do
 
     context 'with normal failure and with fallback success' do
       it 'should run callback' do
-        command = error_command(error_in_command, 42).with_fallback do
+        command = error_command(error_in_command, 42).set_fallback do
           0
         end
         res = nil
@@ -419,7 +419,7 @@ describe Expeditor::Command do
 
     context 'with normal failure and with fallback failure' do
       it 'should not run callback' do
-        command = error_command(error_in_command, 42).with_fallback do |e|
+        command = error_command(error_in_command, 42).set_fallback do |e|
           raise e
         end
         res = nil
@@ -459,7 +459,7 @@ describe Expeditor::Command do
 
     context 'with normal success and with fallback' do
       it 'should not run callback' do
-        command = simple_command(42).with_fallback do
+        command = simple_command(42).set_fallback do
           0
         end
         flag = false
@@ -473,7 +473,7 @@ describe Expeditor::Command do
 
     context 'with normal failure and with fallback success' do
       it 'should not run callback' do
-        command = error_command(error_in_command, 42).with_fallback do
+        command = error_command(error_in_command, 42).set_fallback do
           0
         end
         flag = false
@@ -487,7 +487,7 @@ describe Expeditor::Command do
 
     context 'with normal failure and with fallback failure' do
       it 'should run callback' do
-        command = error_command(error_in_command, 42).with_fallback do |e|
+        command = error_command(error_in_command, 42).set_fallback do |e|
           raise e
         end
         flag = false
@@ -530,7 +530,7 @@ describe Expeditor::Command do
       expect(command.started?).to be true
       expect(command.get).to eq(42)
       expect(command.start).to eq(command)
-      command_f = command.with_fallback { 0 }
+      command_f = command.set_fallback { 0 }
       expect(command_f.get).to eq(42)
       command.wait
     end

--- a/spec/expeditor/command_spec.rb
+++ b/spec/expeditor/command_spec.rb
@@ -198,7 +198,7 @@ describe Expeditor::Command do
       fallback_command = command.with_fallback do
         0
       end
-      expect(fallback_command).not_to eq(command)
+      expect(fallback_command).to eq(command)
       # expect(fallback_command.normal_future).to eq(command.normal_future)
     end
 
@@ -238,18 +238,14 @@ describe Expeditor::Command do
     context 'with fallback' do
       it 'should wait execution' do
         start_time = Time.now
-        command = Expeditor::Command.new do
+        command = Expeditor::Command.new {
           sleep 0.1
           raise error_in_command
-        end
-        command_with_f = command.with_fallback do
+        }.with_fallback {
           sleep 0.1
           42
-        end
-        command_with_f.start
-        command.wait
-        expect(Time.now - start_time).to be_between(0.1, 0.11).inclusive
-        command_with_f.wait
+        }
+        command.start.wait
         expect(Time.now - start_time).to be_between(0.2, 0.22).inclusive
       end
     end

--- a/spec/expeditor/retry_function_spec.rb
+++ b/spec/expeditor/retry_function_spec.rb
@@ -96,7 +96,7 @@ describe Expeditor::Command do
         command = Expeditor::Command.new do
           count += 1
           raise RuntimeError
-        end.with_fallback do
+        end.set_fallback do
           42
         end
         command.start_with_retry(tries: 10, sleep: 0)
@@ -110,7 +110,7 @@ describe Expeditor::Command do
           count += 1
           raise RuntimeError
         end
-        command_f = command.with_fallback do
+        command_f = command.set_fallback do
           42
         end
         command.start_with_retry(tries: 10, sleep: 0)

--- a/spec/expeditor/service_spec.rb
+++ b/spec/expeditor/service_spec.rb
@@ -94,7 +94,7 @@ describe Expeditor::Service do
       3.times do
         Expeditor::Command.new(service: service) {
           raise
-        }.with_fallback { nil }.start.get
+        }.set_fallback { nil }.start.get
       end
       status = service.current_status
       expect(status.success).to eq(0)
@@ -126,7 +126,7 @@ describe Expeditor::Service do
       it 'returns fallback value' do
         result = Expeditor::Command.new(service: service) {
           raise 'error!'
-        }.with_fallback {
+        }.set_fallback {
           0
         }.start.get
         expect(result).to eq(0)
@@ -142,7 +142,7 @@ describe Expeditor::Service do
         expect {
           Expeditor::Command.new(service: service) {
             raise 'error!'
-          }.with_fallback {
+          }.set_fallback {
             0
           }.start.get
         }.to raise_error(RuntimeError, 'error!')


### PR DESCRIPTION
Currently, `with_fallback` behavior is complexity. This cause is cloning in `with_fallback` method.
This change is required from #13 .