### PR TITLE
Drop support for MRI 2.0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 2.0.0
   - 2.1
   - 2.2
   - 2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Master (unreleased)
 
+- Drop support for MRI 2.0.x [#15](https://github.com/cookpad/expeditor/pull/15)
 - Deprecate Expeditor::Command#with_fallback. Use `set_fallback` instead [#14](https://github.com/cookpad/expeditor/pull/14)
 
 ## 0.4.0

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ It is inspired by [Netflix/Hystrix](https://github.com/Netflix/Hystrix).
 
 ## Installation
 
+Expeditor currently supports Ruby 2.1 and higher.
+
 Add this line to your application's Gemfile:
 
 ```ruby

--- a/expeditor.gemspec
+++ b/expeditor.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.0.0'
+
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0.0"
   spec.add_runtime_dependency "concurrent-ruby-ext", "~> 1.0.0"
   spec.add_runtime_dependency "retryable", "> 1.0"

--- a/expeditor.gemspec
+++ b/expeditor.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = '>= 2.1.0'
 
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0.0"
   spec.add_runtime_dependency "concurrent-ruby-ext", "~> 1.0.0"


### PR DESCRIPTION
- Remove MRI 2.0.0 from .travis.yml
- Add `required_ruby_version` into gemspec
- Add message of support ruby version into README