### PR TITLE
Add `Command#run` method to execute task on current thread

### DIFF
--- a/lib/expeditor/command.rb
+++ b/lib/expeditor/command.rb
@@ -17,11 +17,22 @@ module Expeditor
       @normal_future = initial_normal(&block)
       @fallback_var = nil
       @retryable_options = Concurrent::IVar.new
+      @executor = @service.executor
     end
 
     def start
       if not started?
         @dependencies.each(&:start)
+        @normal_future.safe_execute
+      end
+      self
+    end
+
+    def run
+      if not started?
+        @dependencies.each(&:start)
+        @executor = Concurrent::ImmediateExecutor.new
+        @normal_future.instance_variable_set(:@executor, @executor)
         @normal_future.safe_execute
       end
       self
@@ -119,7 +130,7 @@ module Expeditor
       @fallback_var = Concurrent::IVar.new
       @normal_future.add_observer do |_, value, reason|
         if reason != nil
-          future = RichFuture.new(executor: Concurrent.global_io_executor) do
+          future = RichFuture.new(executor: @executor) do
             success, val, reason = Concurrent::SafeTaskExecutor.new(block, rescue_exception: true).execute(reason)
             @fallback_var.send(:complete, success, val, reason)
           end

--- a/spec/expeditor/command_spec.rb
+++ b/spec/expeditor/command_spec.rb
@@ -101,6 +101,75 @@ describe Expeditor::Command do
     end
   end
 
+  describe '#run' do
+    context 'with normal' do
+      it 'should run on current thread' do
+        Thread.current.thread_variable_set('foo', 'bar')
+        command = Expeditor::Command.new do
+          Thread.current.thread_variable_get('foo')
+        end
+        expect(command.run.get).to eq('bar')
+      end
+
+      it 'should return self' do
+        command = simple_command(42)
+        expect(command.run).to eq(command)
+      end
+
+      it 'should ignore from the second time' do
+        count = 0
+        command = Expeditor::Command.new do
+          count += 1
+          count
+        end
+        command.run
+        command.run
+        command.run
+        expect(command.get).to eq(1)
+        expect(count).to eq(1)
+      end
+    end
+
+    context 'with fallback' do
+      it 'should work fallback proc' do
+        command = error_command(error_in_command, nil)
+        command.set_fallback do
+          42
+        end
+
+        expect(command.run.get).to eq(42)
+      end
+
+      it 'should work fallback on current thread' do
+        Thread.current.thread_variable_set("count", 1)
+        command = Expeditor::Command.new do
+          count = Thread.current.thread_variable_get("count")
+          count += 1
+          Thread.current.thread_variable_set("count", count) # => 2
+          raise error_in_command
+        end
+
+        command.set_fallback do
+          count = Thread.current.thread_variable_get("count")
+          count += 1
+          count # => 3
+        end
+
+        expect(command.run.get).to eq(3)
+      end
+
+      it 'should work set_fallback after run' do
+        command = error_command(error_in_command, nil)
+        command.run
+        command.with_fallback do
+          42
+        end
+
+        expect(command.get).to eq(42)
+      end
+    end
+  end
+
   describe '#started?' do
     context 'with started' do
       it 'should be true' do


### PR DESCRIPTION
I've added `Command#run` to execute task on current thread.

e.g.

```ruby
command = Expeditor::Command.new do
  # => Here is Current Thread
end.with_fallback do
  # => Here is Current Thread
end

command.run.get
```

Note
-----

This implementation replaces `@executor` instance variable in `RichFuture` after initialize.
In first implementation, I tried replacing `@normal_future` instance variable in  `Command`. However the implementation has many problems. So, I gave up this.


See #13 

