### PR TITLE
Reduce large number for test case

### DIFF
--- a/spec/expeditor/command_functions_spec.rb
+++ b/spec/expeditor/command_functions_spec.rb
@@ -79,21 +79,21 @@ describe Expeditor::Command do
 
     context 'with large number of horizontal dependencies' do
       it 'should be ok' do
-        commands = 10000.times.map do
+        commands = 100.times.map do
           sleep_command(0.01, 1)
         end
         command = Expeditor::Command.new(dependencies: commands) do |*vs|
           vs.inject(:+)
         end
         command.start
-        expect(command.get).to eq(10000)
+        expect(command.get).to eq(100)
       end
     end
 
     context 'with large number of horizontal dependencies ^ 2 (long test case)' do
       it 'should be ok' do
-        commands = 100.times.map do
-          dependencies = 100.times.map do
+        commands = 20.times.map do
+          dependencies = 20.times.map do
             simple_command(1)
           end
           Expeditor::Command.new(dependencies: dependencies) do |*vs|
@@ -105,20 +105,20 @@ describe Expeditor::Command do
         end
         start = Time.now
         command.start
-        expect(command.get).to eq(10000)
+        expect(command.get).to eq(400)
       end
     end
 
     context 'with large number of vertical dependencies' do
       it 'should be ok' do
         command0 = simple_command(0)
-        command = 1000.times.inject(command0) do |c|
+        command = 100.times.inject(command0) do |c|
           Expeditor::Command.new(dependencies: [c]) do |v|
             v + 1
           end
         end
         command.start
-        expect(command.get).to eq(1000)
+        expect(command.get).to eq(100)
       end
     end
   end


### PR DESCRIPTION
Because process crashes if create 2048 threads in OS X.

e.g.

```sh
$ bundle exec rspec

Expeditor::Bucket
  #increment
    with same status
      should be increased
    across statuses
      should be ok
  #total
    with no limit exceeded
      should be ok
    with limit exceeded
      should be ok

Expeditor::Command
  circuit break function
    with circuit break
      should reject execution
      should not count circuit break
    with circuit break and wait
      should reject execution and back
    with circuit break (large case)
      should be ok
    with dependency's error of circuit break
      should not fall deadlock

Expeditor::Command
  dependencies function
    with normal and no sleep
      should be ok
    with normal and sleep
      should start dependencies concurrently
    with failure
      should throw error DependencyError
    with sleep and failure
      should throw error immediately
    with large number of horizontal dependencies
      should be ok
    with large number of horizontal dependencies ^ 2 (long test case)
      should be ok
    with large number of vertical dependencies
      should be ok (FAILED - 1)
  fallback function
    with normal
      should be normal value
    with failure of normal
      should be fallback value
    with fail both
      should throw fallback error
    with large number of commands
      should not throw any errors
  entire
    with complex example
      should be ok

Expeditor::Command
  #start
    with normal
      should not block
      should return self
      should ignore from the second time
    with thread pool overflow
      should throw RejectedExecutionError in #get, not #start
    with double starting
      should not throw MultipleAssignmentError
  #started?
    with started
      should be true
    with not started
      should be false
    with fallback
      should be true (both) if the command with no fallback is started
      should be true (both) if the command with fallback is started
  #get
    with success
      should return success value
    with sleep and success
      should block and return success value
    with failure
      should throw exception
      should throw exception (no deadlock)
    with not started
      should throw NotStartedError
    with timeout
      should throw Timeout::Error
  #set_fallback
    should return new command and same normal_future
    should not block
    with normal success
      should return normal result
  #wait
    with single
      should wait execution
    with fallback
      should wait execution
    with fallback but normal success
      should not wait fallback execution
    with not started
      should throw NotStartedError
  #on_complete
    with normal success and without fallback
      should run callback with success
    with normal success and with fallback
      should run callback with success
    with normal failure and without fallback
      should run callback with failure
    with normal failure and with fallback success
      should run callback with success
    with normal failure and with fallback failure
      should run callback with failure
  #on_success
    with normal success and without fallback
      should run callback
    with normal success and with fallback
      should run callback
    with normal failure and without fallback
      should not run callback
    with normal failure and with fallback success
      should run callback
    with normal failure and with fallback failure
      should not run callback
  #on_failure
    with normal success and without fallback
      should not run callback
    with normal failure and without fallback
      should run callback
    with normal success and with fallback
      should not run callback
    with normal failure and with fallback success
      should not run callback
    with normal failure and with fallback failure
      should run callback
  #chain
    with normal
      should chain command
    with options
      should recognize options
  .const
    should be ok
  .start
    should be already started

Expeditor::Command
  #start_with_retry
    with 3 tries
      should be run 3 times
    with 0 tries
      should be run 0 time and return nil
    with retry -1 time
      should be run 1 times
    with passsing error
      should not retry
    with retry in case of only specified errors
      should retry
    with retry and timeout
      should be timed out when over time
    with retry and circuit break
      should break when over threshold
    with retry with fallback
      should retry if start fallback command
      should retry if start normal command
    with (1) start and (2) start_with_retry
      should ignore start_with_retry
    with (1) start_with_retry and (2) start
      should ignore start

Expeditor::RichFuture
  #get
    with success
      should return normal value
    with failure
      should raise exception
  #get_or_else
    with success
      should return normal value
    with recover
      should raise exception
    with also failure
      should raise exception
  #set
    should success immediately
    should notify to observer
    should throw error if it is already completed
  #safe_set
    should set immediately
    should not throw error although it is already completed
    should ignore if it is already completed
  #fail
    should fail immediately
    should notify to observer
    should throw error if it is already completed
  #safe_fail
    should fail immediately
    should not throw error although it is already completed
    should ignore if it is already completed
  #executed?
    with executed
      should be true
    with not executed
      should be false
  #execute
    with thread pool overflow
      should throw RejectedExecutionError
  #safe_execute
    with thread pool overflow
      should not throw RejectedExecutionError

Expeditor::Service
  #open?
    with no count
      should be false
    within non_break_count
      should be false
    with non_break_count exceeded but not exceeded threshold
      should be false
    with non_break_count and threshold exceeded
      should be true
  #shutdown
    should reject execution
    should not kill queued tasks
  #current_status
    returns current status
  #reset_status!
    resets the service's status
  #fallback_enabled
    fallback_enabled is true
      returns fallback value
    fallback_enabled is false
      does not call fallback and raises error

Expeditor::Status
  #initialize
    should be zero all
  #increment
    with success increment
      should be increased only success
      should be increased normally if #increment is called in parallel (FAILED - 2)
    with all increment
      should be increased all

Failures:

  1) Expeditor::Command dependencies function with large number of vertical dependencies should be ok
     Failure/Error: v + 1

     NoMethodError:
       undefined method `+' for nil:NilClass
     # ./spec/expeditor/command_functions_spec.rb:117:in `block (6 levels) in <top (required)>'
     # ./lib/expeditor/command.rb:137:in `breakable_block'
     # ./lib/expeditor/command.rb:148:in `retryable_block'
     # ./lib/expeditor/command.rb:158:in `timeout_block'
     # ./lib/expeditor/command.rb:189:in `block in initial_normal'
     # /Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/concurrent-ruby-1.0.2/lib/concurrent/executor/safe_task_executor.rb:24:in `block in execute'
     # /Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/concurrent-ruby-1.0.2/lib/concurrent/synchronization/mri_lockable_object.rb:38:in `block in synchronize'
     # /Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/concurrent-ruby-1.0.2/lib/concurrent/synchronization/mri_lockable_object.rb:38:in `synchronize'
     # /Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/concurrent-ruby-1.0.2/lib/concurrent/synchronization/mri_lockable_object.rb:38:in `synchronize'
     # /Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/concurrent-ruby-1.0.2/lib/concurrent/executor/safe_task_executor.rb:19:in `execute'
     # /Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/concurrent-ruby-1.0.2/lib/concurrent/ivar.rb:170:in `safe_execute'
     # ./lib/expeditor/rich_future.rb:52:in `safe_execute'
     # /Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/concurrent-ruby-1.0.2/lib/concurrent/future.rb:52:in `block in execute'
     # /Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/concurrent-ruby-1.0.2/lib/concurrent/executor/ruby_thread_pool_executor.rb:348:in `run_task'
     # /Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/concurrent-ruby-1.0.2/lib/concurrent/executor/ruby_thread_pool_executor.rb:337:in `block (3 levels) in create_worker'
     # /Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/concurrent-ruby-1.0.2/lib/concurrent/executor/ruby_thread_pool_executor.rb:320:in `loop'
     # /Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/concurrent-ruby-1.0.2/lib/concurrent/executor/ruby_thread_pool_executor.rb:320:in `block (2 levels) in create_worker'
     # /Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/concurrent-ruby-1.0.2/lib/concurrent/executor/ruby_thread_pool_executor.rb:319:in `catch'
     # /Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/concurrent-ruby-1.0.2/lib/concurrent/executor/ruby_thread_pool_executor.rb:319:in `block in create_worker'

  2) Expeditor::Status#increment with success increment should be increased normally if #increment is called in parallel
     Failure/Error:
       Thread.start do
         status.increment :success
       end

     ThreadError:
       can't create Thread: Resource temporarily unavailable
     # ./spec/expeditor/status_spec.rb:28:in `start'
     # ./spec/expeditor/status_spec.rb:28:in `block (5 levels) in <top (required)>'
     # ./spec/expeditor/status_spec.rb:27:in `times'
     # ./spec/expeditor/status_spec.rb:27:in `each'
     # ./spec/expeditor/status_spec.rb:27:in `map'
     # ./spec/expeditor/status_spec.rb:27:in `block (4 levels) in <top (required)>'

Finished in 13.22 seconds (files took 0.23419 seconds to load)
108 examples, 2 failures

Failed examples:

rspec ./spec/expeditor/command_functions_spec.rb:113 # Expeditor::Command dependencies function with large number of vertical dependencies should be ok
rspec ./spec/expeditor/status_spec.rb:25 # Expeditor::Status#increment with success increment should be increased normally if #increment is called in parallel


```


Ref
---

- http://www.jstorimer.com/blogs/workingwithcode/7970125-how-many-threads-is-too-many