### PR TITLE
Do not allow set_fallback call after command is started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Drop support for MRI 2.0.x [#15](https://github.com/cookpad/expeditor/pull/15)
 - Deprecate Expeditor::Command#with_fallback. Use `set_fallback` instead [#14](https://github.com/cookpad/expeditor/pull/14)
+- Do not allow set_fallback call after command is started. [#18](https://github.com/cookpad/expeditor/pull/18)
 
 ## 0.4.0
 - Add Expeditor::Service#current\_status [#9](https://github.com/cookpad/expeditor/issues/9)

--- a/lib/expeditor/command.rb
+++ b/lib/expeditor/command.rb
@@ -57,6 +57,9 @@ module Expeditor
     end
 
     def set_fallback(&block)
+      if started?
+        raise AlreadyStartedError, "Do not allow set_fallback call after command is started"
+      end
       reset_fallback(&block)
       self
     end

--- a/lib/expeditor/errors.rb
+++ b/lib/expeditor/errors.rb
@@ -4,10 +4,15 @@ module Expeditor
   NotStartedError = Class.new(StandardError)
   RejectedExecutionError = Concurrent::RejectedExecutionError
   CircuitBreakError = Class.new(StandardError)
+  AlreadyStartedError = Class.new(StandardError)
   class DependencyError < StandardError
     attr :error
     def initialize(e)
       @error = e
+    end
+
+    def message
+      @error.message
     end
   end
 end

--- a/spec/expeditor/circuit_break_function_spec.rb
+++ b/spec/expeditor/circuit_break_function_spec.rb
@@ -105,7 +105,7 @@ describe Expeditor::Command do
           end
         end
         reason = nil
-        command = Expeditor::Command.start(
+        command = Expeditor::Command.new(
           service: service,
           dependencies: failure_commands + success_commands,
         ) do |*vs|
@@ -114,6 +114,7 @@ describe Expeditor::Command do
           reason = e
           0
         end
+        command.start
         expect(command.get).to eq(0)
         expect(reason).to be_instance_of(Expeditor::CircuitBreakError)
         service.shutdown

--- a/spec/expeditor/circuit_break_function_spec.rb
+++ b/spec/expeditor/circuit_break_function_spec.rb
@@ -92,11 +92,12 @@ describe Expeditor::Command do
           sleep: 0,
         )
         failure_commands = 2000.times.map do
-          Expeditor::Command.start(service: service) do
+          command = Expeditor::Command.new(service: service) do
             raise RuntimeError
           end.set_fallback do
             1
           end
+          command.start
         end
         success_commands = 8000.times.map do
           Expeditor::Command.start(service: service) do


### PR DESCRIPTION
I've changed `Command#set_fallback` behavior. The change is breaking.
After `Command#start` is called, can't set fallback.



Current behavior
---

```ruby
command = Expeditor::Command.new{xxx}
command.start
command.with_fallback{xxx} # => it's allowed
```

Changed behavior
----

```ruby
command = Expeditor::Command.new{xxx}
command.start
command.with_fallback{xxx} # => throw AlreadyStartedError
```

If the above code exists, please fix to the following code.

```ruby
command = Expeditor::Command.new{xxx}
command.with_fallback{xxx}
command.start
```

Current behavior is not natural. And in #13 's implementation, keeping the behavior is hard. So, I've changed it.