### PR TITLE
Refactor spec

### DIFF
--- a/spec/expeditor/command_functions_spec.rb
+++ b/spec/expeditor/command_functions_spec.rb
@@ -33,7 +33,7 @@ describe Expeditor::Command do
     context 'with failure' do
       it 'should throw error DependencyError' do
         command1 = simple_command(42)
-        command2 = error_command(error_in_command, 42)
+        command2 = error_command(error_in_command)
         command3 = Expeditor::Command.new(dependencies: [command1, command2]) do |v1, v2|
           v1 + v2
         end
@@ -46,7 +46,7 @@ describe Expeditor::Command do
       it 'should throw error immediately' do
         start = Time.now
         command1 = sleep_command(0.1, 42)
-        command2 = error_command(error_in_command, 100)
+        command2 = error_command(error_in_command)
         command3 = Expeditor::Command.new(dependencies: [command1, command2]) do |v1, v2|
           v1 + v2
         end
@@ -82,7 +82,6 @@ describe Expeditor::Command do
         command = Expeditor::Command.new(dependencies: commands) do |*vs|
           vs.inject(:+)
         end
-        start = Time.now
         command.start
         expect(command.get).to eq(400)
       end
@@ -113,7 +112,7 @@ describe Expeditor::Command do
 
     context 'with failure of normal' do
       it 'should be fallback value' do
-        command = error_command(error_in_command, 42).set_fallback { 0 }
+        command = error_command(error_in_command).set_fallback { 0 }
         command.start
         expect(command.get).to eq(0)
       end
@@ -123,7 +122,7 @@ describe Expeditor::Command do
       let(:error_in_fallback) { Class.new(Exception) }
 
       it 'should throw fallback error' do
-        command = error_command(error_in_command, 42).set_fallback do
+        command = error_command(error_in_command).set_fallback do
           raise error_in_fallback
         end
         command.start

--- a/spec/expeditor/command_functions_spec.rb
+++ b/spec/expeditor/command_functions_spec.rb
@@ -1,27 +1,6 @@
 require 'spec_helper'
 
 describe Expeditor::Command do
-
-  def simple_command(v, opts = {})
-    Expeditor::Command.new(opts) do
-      v
-    end
-  end
-
-  def sleep_command(n, v, opts = {})
-    Expeditor::Command.new(opts) do
-      sleep n
-      v
-    end
-  end
-
-  def error_command(e, v, opts = {})
-    Expeditor::Command.new(opts) do
-      raise e
-      v
-    end
-  end
-
   let(:error_in_command) { Class.new(StandardError) }
 
   describe 'dependencies function' do

--- a/spec/expeditor/command_spec.rb
+++ b/spec/expeditor/command_spec.rb
@@ -141,14 +141,14 @@ describe Expeditor::Command do
 
     context 'with failure' do
       it 'should throw exception' do
-        command = error_command(error_in_command, nil)
+        command = error_command(error_in_command)
         command.start
         expect { command.get }.to raise_error(error_in_command)
       end
 
       it 'should throw exception (no deadlock)' do
         error = Class.new(Exception)
-        command = error_command(error, nil)
+        command = error_command(error)
         command.start
         expect { command.get }.to raise_error(error)
       end
@@ -183,7 +183,7 @@ describe Expeditor::Command do
     end
 
     it 'should not block' do
-      command = error_command(error_in_command, nil)
+      command = error_command(error_in_command)
       start_time = Time.now
       fallback_command = command.set_fallback do
         sleep 0.1
@@ -298,7 +298,7 @@ describe Expeditor::Command do
 
     context 'with normal failure and without fallback' do
       it 'should run callback with failure' do
-        command = error_command(error_in_command, 42)
+        command = error_command(error_in_command)
         success = nil
         value = nil
         reason = nil
@@ -316,7 +316,7 @@ describe Expeditor::Command do
 
     context 'with normal failure and with fallback success' do
       it 'should run callback with success' do
-        command = error_command(error_in_command, 42).set_fallback { 0 }
+        command = error_command(error_in_command).set_fallback { 0 }
         success = nil
         value = nil
         reason = nil
@@ -334,7 +334,7 @@ describe Expeditor::Command do
 
     context 'with normal failure and with fallback failure' do
       it 'should run callback with failure' do
-        command = error_command(error_in_command, 42).set_fallback do |e|
+        command = error_command(error_in_command).set_fallback do |e|
           raise e
         end
         success = nil
@@ -380,7 +380,7 @@ describe Expeditor::Command do
 
     context 'with normal failure and without fallback' do
       it 'should not run callback' do
-        command = error_command(error_in_command, 42)
+        command = error_command(error_in_command)
         res = nil
         command.on_success do |v|
           res = v
@@ -392,7 +392,7 @@ describe Expeditor::Command do
 
     context 'with normal failure and with fallback success' do
       it 'should run callback' do
-        command = error_command(error_in_command, 42).set_fallback do
+        command = error_command(error_in_command).set_fallback do
           0
         end
         res = nil
@@ -406,7 +406,7 @@ describe Expeditor::Command do
 
     context 'with normal failure and with fallback failure' do
       it 'should not run callback' do
-        command = error_command(error_in_command, 42).set_fallback do |e|
+        command = error_command(error_in_command).set_fallback do |e|
           raise e
         end
         res = nil
@@ -434,7 +434,7 @@ describe Expeditor::Command do
 
     context 'with normal failure and without fallback' do
       it 'should run callback' do
-        command = error_command(error_in_command, 42)
+        command = error_command(error_in_command)
         flag = false
         command.on_failure do |e|
           flag = true
@@ -460,7 +460,7 @@ describe Expeditor::Command do
 
     context 'with normal failure and with fallback success' do
       it 'should not run callback' do
-        command = error_command(error_in_command, 42).set_fallback do
+        command = error_command(error_in_command).set_fallback do
           0
         end
         flag = false
@@ -474,7 +474,7 @@ describe Expeditor::Command do
 
     context 'with normal failure and with fallback failure' do
       it 'should run callback' do
-        command = error_command(error_in_command, 42).set_fallback do |e|
+        command = error_command(error_in_command).set_fallback do |e|
           raise e
         end
         flag = false

--- a/spec/expeditor/command_spec.rb
+++ b/spec/expeditor/command_spec.rb
@@ -1,27 +1,6 @@
 require 'spec_helper'
 
 describe Expeditor::Command do
-
-  def simple_command(v, opts = {})
-    Expeditor::Command.new(opts) do
-      v
-    end
-  end
-
-  def sleep_command(n, v, opts = {})
-    Expeditor::Command.new(opts) do
-      sleep n
-      v
-    end
-  end
-
-  def error_command(e, v, opts = {})
-    Expeditor::Command.new(opts) do
-      raise e
-      v
-    end
-  end
-
   let(:error_in_command) { Class.new(StandardError) }
 
   describe '#start' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,4 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'expeditor'
+
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }

--- a/spec/support/command.rb
+++ b/spec/support/command.rb
@@ -1,0 +1,19 @@
+def simple_command(v, opts = {})
+  Expeditor::Command.new(opts) do
+    v
+  end
+end
+
+def sleep_command(n, v, opts = {})
+  Expeditor::Command.new(opts) do
+    sleep n
+    v
+  end
+end
+
+def error_command(e, v, opts = {})
+  Expeditor::Command.new(opts) do
+    raise e
+    v
+  end
+end

--- a/spec/support/command.rb
+++ b/spec/support/command.rb
@@ -1,18 +1,24 @@
-def simple_command(v, opts = {})
-  Expeditor::Command.new(opts) do
-    v
+module CommandHelpers
+  def simple_command(v, opts = {})
+    Expeditor::Command.new(opts) do
+      v
+    end
+  end
+
+  def sleep_command(n, v, opts = {})
+    Expeditor::Command.new(opts) do
+      sleep n
+      v
+    end
+  end
+
+  def error_command(e, opts = {})
+    Expeditor::Command.new(opts) do
+      raise e
+    end
   end
 end
 
-def sleep_command(n, v, opts = {})
-  Expeditor::Command.new(opts) do
-    sleep n
-    v
-  end
-end
-
-def error_command(e, opts = {})
-  Expeditor::Command.new(opts) do
-    raise e
-  end
+RSpec.configure do |c|
+  c.include CommandHelpers
 end

--- a/spec/support/command.rb
+++ b/spec/support/command.rb
@@ -11,9 +11,8 @@ def sleep_command(n, v, opts = {})
   end
 end
 
-def error_command(e, v, opts = {})
+def error_command(e, opts = {})
   Expeditor::Command.new(opts) do
     raise e
-    v
   end
 end


### PR DESCRIPTION
- DRY helper code in spec
- remove unnecessary return value of `error_command`