### PR TITLE
Bump up to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Master (unreleased)
+<!-- ## Master (unreleased) -->
+
+## 0.5.0
 
 - Add a `current_thread` option of `Expeditor::Command#start` method to execute a task on current thread [#13](https://github.com/cookpad/expeditor/pull/13)
 - Drop support for MRI 2.0.x [#15](https://github.com/cookpad/expeditor/pull/15)

--- a/lib/expeditor/version.rb
+++ b/lib/expeditor/version.rb
@@ -1,3 +1,3 @@
 module Expeditor
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION

- Add a `current_thread` option of `Expeditor::Command#start` method to execute a task on current thread [#13](https://github.com/cookpad/expeditor/pull/13)
- Drop support for MRI 2.0.x [#15](https://github.com/cookpad/expeditor/pull/15)
- Deprecate Expeditor::Command#with_fallback. Use `set_fallback` instead [#14](https://github.com/cookpad/expeditor/pull/14)
- Do not allow set_fallback call after command is started. [#18](https://github.com/cookpad/expeditor/pull/18)

I'll merge and release to rubygems after test passed