### PR TITLE
Stop using protected method

### DIFF
--- a/lib/expeditor/command.rb
+++ b/lib/expeditor/command.rb
@@ -238,7 +238,11 @@ module Expeditor
           if @fallback_block
             future = RichFuture.new(executor: executor) do
               success, value, reason = Concurrent::SafeTaskExecutor.new(@fallback_block, rescue_exception: true).execute(reason)
-              @ivar.send(:complete, success, value, reason)
+              if success
+                @ivar.set(value)
+              else
+                @ivar.fail(reason)
+              end
             end
             future.safe_execute
           else

--- a/lib/expeditor/command.rb
+++ b/lib/expeditor/command.rb
@@ -234,18 +234,17 @@ module Expeditor
     def prepare(executor = @service.executor)
       @normal_future = initial_normal(executor, &@normal_block)
       @normal_future.add_observer do |_, value, reason|
-        if reason # failure
-          if @fallback_block
-            success, value, reason = Concurrent::SafeTaskExecutor.new(@fallback_block, rescue_exception: true).execute(reason)
-            if success
-              @ivar.set(value)
-            else
-              @ivar.fail(reason)
-            end
+        case
+        when reason && @fallback_block
+          success, value, reason = Concurrent::SafeTaskExecutor.new(@fallback_block, rescue_exception: true).execute(reason)
+          if success
+            @ivar.set(value)
           else
             @ivar.fail(reason)
           end
-        else # success
+        when reason
+          @ivar.fail(reason)
+        else                    # success
           @ivar.set(value)
         end
       end

--- a/lib/expeditor/command.rb
+++ b/lib/expeditor/command.rb
@@ -236,15 +236,12 @@ module Expeditor
       @normal_future.add_observer do |_, value, reason|
         if reason # failure
           if @fallback_block
-            future = RichFuture.new(executor: executor) do
-              success, value, reason = Concurrent::SafeTaskExecutor.new(@fallback_block, rescue_exception: true).execute(reason)
-              if success
-                @ivar.set(value)
-              else
-                @ivar.fail(reason)
-              end
+            success, value, reason = Concurrent::SafeTaskExecutor.new(@fallback_block, rescue_exception: true).execute(reason)
+            if success
+              @ivar.set(value)
+            else
+              @ivar.fail(reason)
             end
-            future.safe_execute
           else
             @ivar.fail(reason)
           end


### PR DESCRIPTION
Because Concurrent::Ivar#complete is a protected method, I replaced it with public methods( #set and #fail).

And I removed unnecessary future object. This object is invoked immediately after when it is created. I think It is not need to use here.