### PR TITLE
Stop using #send to set value to Concurrent::IVar

### DIFF
--- a/lib/expeditor/command.rb
+++ b/lib/expeditor/command.rb
@@ -238,7 +238,11 @@ module Expeditor
           if @fallback_block
             future = RichFuture.new(executor: executor) do
               success, value, reason = Concurrent::SafeTaskExecutor.new(@fallback_block, rescue_exception: true).execute(reason)
-              @ivar.send(:complete, success, value, reason)
+              if success
+                @ivar.set(value)
+              else
+                @ivar.fail(reason)
+              end
             end
             future.safe_execute
           else


### PR DESCRIPTION
This is follow-up PR for https://github.com/cookpad/expeditor/pull/21.

This refactoring also looks to me.

FYI @ganmacs @cookpad/dev-infra 