### PR TITLE
Improve default configuration of circuit breaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ Expeditor's circuit breaker has a few configuration for how it collects service 
 For service metrics, Expeditor collects them with the given time window.
 The metrics is guradually collected by breaking given time window into some peice of short time windows and resetting previous metrics when passing each short time window.
 
-`non_break_count` is used to ignore requests to the service which is not frequentlly requested.
+`non_break_count` is used to ignore requests to the service which is not frequentlly requested. Configure this value considering your estimated "requests per period to the service".
+For example, when `period = 10` and `non_break_count = 20` and the requests do not occur more than 20 per 10 seconds, the circuit never opens because Expeditor ignores that "small number of requests".
+If you don't ignore the failures in that case, set `non_break_count` to smaller value than `20`.
 
 ```ruby
 service = Expeditor::Service.new(

--- a/README.md
+++ b/README.md
@@ -143,10 +143,10 @@ The metrics is guradually collected by breaking given time window into some peic
 
 ```ruby
 service = Expeditor::Service.new(
-  threshold: 0.5,      # If the failure rate is more than or equal to threshold, the circuit will be opened.
-  sleep: 1,            # If once the circuit is opened, the circuit is still open until sleep time seconds is passed even though failure rate is less than threshold.
-  non_break_count: 100 # If the total count of metrics is not more than non_break_count, the circuit is not opened even though failure rate is more than threshold.
-  period: 10,          # Time window of collecting metrics (in seconds).
+  threshold: 0.5,     # If the failure rate is more than or equal to threshold, the circuit will be opened.
+  sleep: 1,           # If once the circuit is opened, the circuit is still open until sleep time seconds is passed even though failure rate is less than threshold.
+  non_break_count: 20 # If the total count of metrics is not more than non_break_count, the circuit is not opened even though failure rate is more than threshold.
+  period: 10,         # Time window of collecting metrics (in seconds).
 )
 
 command = Expeditor::Command.new(service: service) do

--- a/lib/expeditor/service.rb
+++ b/lib/expeditor/service.rb
@@ -8,7 +8,7 @@ module Expeditor
     def initialize(opts = {})
       @executor = opts.fetch(:executor) { Concurrent::ThreadPoolExecutor.new }
       @threshold = opts.fetch(:threshold, 0.5) # is 0.5 ok?
-      @non_break_count = opts.fetch(:non_break_count, 100) # is 100 ok?
+      @non_break_count = opts.fetch(:non_break_count, 20)
       @sleep = opts.fetch(:sleep, 1)
       @bucket_opts = {
         size: 10,

--- a/lib/expeditor/service.rb
+++ b/lib/expeditor/service.rb
@@ -7,7 +7,7 @@ module Expeditor
 
     def initialize(opts = {})
       @executor = opts.fetch(:executor) { Concurrent::ThreadPoolExecutor.new }
-      @threshold = opts.fetch(:threshold, 0.5) # is 0.5 ok?
+      @threshold = opts.fetch(:threshold, 0.5)
       @non_break_count = opts.fetch(:non_break_count, 20)
       @sleep = opts.fetch(:sleep, 1)
       @bucket_opts = {


### PR DESCRIPTION
Current default configuration of `non_break_count` for circuit breaking feature is a little bit large to typical usecases. I propose to reduce this number.
I refer original Hytrix's default configuration value and `20` service calls during 10 seconds can be more reasonable value to me: https://github.com/Netflix/Hystrix/wiki/Configuration#circuitBreaker.requestVolumeThreshold

@cookpad/dev-infra What do you think of this?

cc @amutake just FYI