### PR TITLE
Return proper status of service

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ command = Expeditor::Command.new(service: service) do
   ...
 end
 
-service.current_status
+service.status
 # => #<Expeditor::Status:0x007fdeeeb18468 @break=0, @dependency=0, @failure=0, @rejection=0, @success=0, @timeout=0>
 
 service.reset_status!  # reset status in the service

--- a/examples/circuit_breaker.rb
+++ b/examples/circuit_breaker.rb
@@ -20,7 +20,7 @@ loop do
   }.start
 
   p command.get
-  p service.current_status
+  p service.status
   puts
 
   i += 1

--- a/lib/expeditor/bucket.rb
+++ b/lib/expeditor/bucket.rb
@@ -29,14 +29,14 @@ module Expeditor
     def total
       acc = @mutex.synchronize do
         update
-        @statuses.inject([0, 0, 0, 0, 0, 0]) do |acc, s|
-          acc[0] += s.success
-          acc[1] += s.failure
-          acc[2] += s.rejection
-          acc[3] += s.timeout
-          acc[4] += s.break
-          acc[5] += s.dependency
-          acc
+        @statuses.inject([0, 0, 0, 0, 0, 0]) do |i, s|
+          i[0] += s.success
+          i[1] += s.failure
+          i[2] += s.rejection
+          i[3] += s.timeout
+          i[4] += s.break
+          i[5] += s.dependency
+          i
         end
       end
       status = Expeditor::Status.new

--- a/lib/expeditor/service.rb
+++ b/lib/expeditor/service.rb
@@ -70,7 +70,13 @@ module Expeditor
       @executor.shutdown
     end
 
+    def status
+      @bucket.total
+    end
+
+    # @deprecated
     def current_status
+      warn 'Expeditor::Service#current_status is deprecated. Please use #status instead'
       @bucket.current
     end
 

--- a/spec/expeditor/service_spec.rb
+++ b/spec/expeditor/service_spec.rb
@@ -88,7 +88,7 @@ describe Expeditor::Service do
     end
   end
 
-  describe '#current_status' do
+  describe '#status' do
     let(:service) { Expeditor::Service.new(sleep: 10) }
     it 'returns current status' do
       3.times do
@@ -96,9 +96,18 @@ describe Expeditor::Service do
           raise
         }.set_fallback { nil }.start.get
       end
-      status = service.current_status
+      status = service.status
       expect(status.success).to eq(0)
       expect(status.failure).to eq(3)
+    end
+  end
+
+  describe '#current_status' do
+    it 'warns deprecation' do
+      service = Expeditor::Service.new
+      expect {
+        service.current_status
+      }.to output(/current_status is deprecated/).to_stderr
     end
   end
 


### PR DESCRIPTION
Expeditor collects metrics in a gradual manner as in README.
`#current_status` gets metrics only from split short time window and it's
not the "status" in the Expeditor's context. To return proper status,
use `Bucket#total` instead.

@makimoto @cookpad/dev-infra How about this change?