### PR TITLE
We should not depend on this in a gemspec

### DIFF
--- a/expeditor.gemspec
+++ b/expeditor.gemspec
@@ -22,10 +22,10 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.1.0'
 
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0.0"
-  spec.add_runtime_dependency "concurrent-ruby-ext", "~> 1.0.0"
   spec.add_runtime_dependency "retryable", "> 1.0"
 
   spec.add_development_dependency "bundler"
+  spec.add_development_dependency "concurrent-ruby-ext", "~> 1.0.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", ">= 3.0.0"
 end


### PR DESCRIPTION
User should be able to select whether use or not:
https://github.com/ruby-concurrency/concurrent-ruby/blob/v1.0.5/README.md#note-for-gem-developers

@cookpad/dev-infra Any thoughts?