### PR TITLE
Fix broken, fragile and slow tests around circuit breaker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 /vendor/
+.ruby-version

--- a/lib/expeditor/service.rb
+++ b/lib/expeditor/service.rb
@@ -47,6 +47,10 @@ module Expeditor
     end
 
     # break circuit?
+    #
+    # XXX: support half-open state to make use of `sleep` option.
+    # Currently, `sleep` option is useless because we mark failure again even after passing
+    # the `sleep` time.
     def open?
       if @breaking
         if Time.now - @break_start > @sleep

--- a/spec/expeditor/bucket_spec.rb
+++ b/spec/expeditor/bucket_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Expeditor::Bucket do
+RSpec.describe Expeditor::Bucket do
   describe '#increment' do
     context 'with same status' do
       it 'should be increased' do

--- a/spec/expeditor/bucket_spec.rb
+++ b/spec/expeditor/bucket_spec.rb
@@ -26,26 +26,27 @@ describe Expeditor::Bucket do
   describe '#total' do
     context 'with no limit exceeded' do
       it 'should be ok' do
-        size = 10
-        per = 0.05
+        size = 1000
+        per = 0.001
         bucket = Expeditor::Bucket.new(size: size, per: per)
-        size.times do |n|
+        20.times do |n|
           bucket.increment :success
-          sleep per if n != size - 1
+          sleep 0.002
         end
-        expect(bucket.total.success).to eq(size)
+        expect(bucket.current.success).not_to eq(20)
+        expect(bucket.total.success).to eq(20)
       end
     end
 
     context 'with limit exceeded' do
       it 'should be ok' do
-        size = 10
-        per = 0.01
+        size = 5
+        per = 0.001
         bucket = Expeditor::Bucket.new(size: size, per: per)
-        100.times do
+        10.times do
           bucket.increment :success
         end
-        sleep per * size
+        sleep 0.008
         expect(bucket.total.success).to eq(0)
       end
     end

--- a/spec/expeditor/circuit_break_function_spec.rb
+++ b/spec/expeditor/circuit_break_function_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Expeditor::Command do
         end
         command.start
 
-        expect(command.get).to eq(result)
+        expect(command.get).to equal(result)
         expect(reason).to be_instance_of(Expeditor::CircuitBreakError)
         service.shutdown
       end

--- a/spec/expeditor/circuit_break_function_spec.rb
+++ b/spec/expeditor/circuit_break_function_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Expeditor::Command do
+RSpec.describe Expeditor::Command do
   describe 'circuit break function' do
     context 'with circuit break' do
       it 'should reject execution' do

--- a/spec/expeditor/circuit_break_function_spec.rb
+++ b/spec/expeditor/circuit_break_function_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Expeditor::Command do
     end
 
     context 'with circuit break (large case)' do
-      specify 'circuit will be opened after 100 failure and it skips success_commands' do
+      specify 'circuit will be opened after 100 failure and skip success_commands' do
         service = Expeditor::Service.new(
           executor: Concurrent::ThreadPoolExecutor.new(max_threads: 100),
           threshold: 0.1,

--- a/spec/expeditor/command_functions_spec.rb
+++ b/spec/expeditor/command_functions_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Expeditor::Command do
+RSpec.describe Expeditor::Command do
   let(:error_in_command) { Class.new(StandardError) }
 
   describe 'dependencies function' do

--- a/spec/expeditor/command_spec.rb
+++ b/spec/expeditor/command_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Expeditor::Command do
+RSpec.describe Expeditor::Command do
   let(:error_in_command) { Class.new(StandardError) }
 
   describe '#start' do

--- a/spec/expeditor/current_thread_function_spec.rb
+++ b/spec/expeditor/current_thread_function_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Expeditor::Command do
+RSpec.describe Expeditor::Command do
   let(:error_in_command) { Class.new(StandardError) }
 
   describe '#start' do

--- a/spec/expeditor/retry_function_spec.rb
+++ b/spec/expeditor/retry_function_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Expeditor::Command do
+RSpec.describe Expeditor::Command do
   describe '#start_with_retry' do
     context 'with 3 tries' do
       it 'should be run 3 times' do

--- a/spec/expeditor/rich_future_spec.rb
+++ b/spec/expeditor/rich_future_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Expeditor::RichFuture do
+RSpec.describe Expeditor::RichFuture do
   let(:error_in_future) { Class.new(StandardError) }
 
   describe '#get' do

--- a/spec/expeditor/service_spec.rb
+++ b/spec/expeditor/service_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Expeditor::Service do
+RSpec.describe Expeditor::Service do
   describe '#open?' do
     context 'with no count' do
       it 'should be false' do

--- a/spec/expeditor/service_spec.rb
+++ b/spec/expeditor/service_spec.rb
@@ -89,16 +89,18 @@ describe Expeditor::Service do
   end
 
   describe '#status' do
-    let(:service) { Expeditor::Service.new(sleep: 10) }
     it 'returns current status' do
+      # Set large value of period in case test takes long time.
+      service = Expeditor::Service.new(period: 100)
+
       3.times do
         Expeditor::Command.new(service: service) {
           raise
         }.set_fallback { nil }.start.get
       end
-      status = service.status
-      expect(status.success).to eq(0)
-      expect(status.failure).to eq(3)
+
+      expect(service.status.success).to eq(0)
+      expect(service.status.failure).to eq(3)
     end
   end
 
@@ -125,7 +127,7 @@ describe Expeditor::Service do
   end
 
   describe '#fallback_enabled' do
-    let(:service) { Expeditor::Service.new(sleep: 10) }
+    let(:service) { Expeditor::Service.new(period: 10) }
 
     context 'fallback_enabled is true' do
       before do

--- a/spec/expeditor/service_spec.rb
+++ b/spec/expeditor/service_spec.rb
@@ -74,17 +74,17 @@ describe Expeditor::Service do
 
     it 'should not kill queued tasks' do
       service = Expeditor::Service.new
-      commands = 100.times.map do
+      commands = (0..2).map do |i|
         Expeditor::Command.new(service: service) do
-          sleep 0.01
+          # Trigger service.shutdown while processing commands
+          service.shutdown if i == 1
           1
         end
       end
       command = Expeditor::Command.start(service: service, dependencies: commands) do |*vs|
         vs.inject(:+)
       end
-      service.shutdown
-      expect(command.get).to eq(100)
+      expect(command.get).to eq(3)
     end
   end
 

--- a/spec/expeditor/status_spec.rb
+++ b/spec/expeditor/status_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Expeditor::Status do
+RSpec.describe Expeditor::Status do
   describe '#initialize' do
     it 'should be zero all' do
       status = Expeditor::Status.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,3 +2,33 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'expeditor'
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  config.filter_run_when_matching :focus
+
+  config.example_status_persistence_file_path = "tmp/rspec_examples.txt"
+
+  config.disable_monkey_patching!
+
+  config.warnings = false
+
+  if config.files_to_run.one?
+    config.default_formatter = 'doc'
+  end
+
+  config.profile_examples = 10
+
+  config.order = :random
+
+  Kernel.srand config.seed
+end


### PR DESCRIPTION
And also

- Introduce RSpec configuration with `rspec --init` so that measure test execution time.
- Ignore `.ruby-version` file.

@cookpad/dev-infra Please take a look.