### PR TITLE
Don't limit upper version of concurrent-ruby

### DIFF
--- a/expeditor.gemspec
+++ b/expeditor.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1.0'
 
-  spec.add_runtime_dependency "concurrent-ruby", "~> 1.0.0"
+  spec.add_runtime_dependency "concurrent-ruby", ">= 1.0.0"
   spec.add_runtime_dependency "retryable", "> 1.0"
 
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "concurrent-ruby-ext", "~> 1.0.0"
+  spec.add_development_dependency "concurrent-ruby-ext", ">= 1.0.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", ">= 3.0.0"
 end


### PR DESCRIPTION
And its "ext" gem.

In my opinion, this is because a gem should not limit possible
compatibility in its gemspec.

@cookpad/dev-infra How about this?