### PR TITLE
Fix bug on cutting passing size

### DIFF
--- a/lib/expeditor/bucket.rb
+++ b/lib/expeditor/bucket.rb
@@ -62,11 +62,37 @@ module Expeditor
       passing = last_passing
       if passing > 0
         @current_start = @current_start + @per_time * passing
-        passing = passing.div @size + @size if passing > 2 * @size
-        passing.times do
+        cut_passing_size_if_possible(passing, @size).times do
           @current_index = next_index
           @statuses[@current_index].reset
         end
+      end
+    end
+
+    # This logic is used for cutting passing size. When passing size is greater
+    # than buckets size, we can cut passing size to less than bucket size
+    # because the buckets are circulated.
+    #
+    # `*` is current position.
+    # When the bucket size is 3:
+    #
+    #   [*, , ]
+    #
+    # Then when the passing = 3, position will be 0 (0-origin):
+    #
+    #   [*, , ] -3> [ ,*, ] -2> [ , ,*] -1> [*, , ]
+    #
+    # Then passing = 6, position will be 0 again:
+    #
+    #   [*, , ] -6> [ ,*, ] -5> [ , ,*] -4> [*, , ] -3> [ ,*, ] -2> [ , ,*] -1> [*, , ]
+    #
+    # In that case we can cut the passing size from 6 to 3.
+    # That is "cut passing size" here.
+    def cut_passing_size_if_possible(passing, size)
+      if passing >= size * 2
+        (passing % size) + size
+      else
+        passing
       end
     end
 

--- a/spec/expeditor/bucket_spec.rb
+++ b/spec/expeditor/bucket_spec.rb
@@ -51,4 +51,23 @@ RSpec.describe Expeditor::Bucket do
       end
     end
   end
+
+  context 'passing many (> size) buckets' do
+    let(:size) { 3 }
+    let(:per) { 0.01 }
+
+    it 'resets all statuses' do
+      bucket = Expeditor::Bucket.new(size: size, per: per)
+      # Make all statuses dirty.
+      3.times do
+        3.times { bucket.increment(:success) }
+        sleep per
+      end
+      # Move to next bucket.
+      sleep per
+      # Pass size + 1 buckets.
+      sleep (per * size)
+      expect(bucket.total.success).to eq(0)
+    end
+  end
 end

--- a/spec/expeditor/bucket_spec.rb
+++ b/spec/expeditor/bucket_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Expeditor::Bucket do
       # Move to next bucket.
       sleep per
       # Pass size + 1 buckets.
-      sleep (per * size)
+      sleep per * size
       expect(bucket.total.success).to eq(0)
     end
   end


### PR DESCRIPTION
Previously the logic is wrong and we cut the passing size to smaller
than needed. See more detail in the commit and code doc.

@cookpad/dev-infra Please take a look.

---

I also plan to refactoring class name of `Bucket` and split its methods into 2 classes because current names are confusing: actually a `Bucket` has multiple pockets or spaces to hold `Status`s and its pockets are linked as circulated, and also a `Bucket`'s pockets are sliced by time.