### PR TITLE
Service#open? is called concurrently

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,4 +2,9 @@ require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
-task default: :spec
+task default: [:spec, :performance_test]
+
+desc 'Check performance'
+task :performance_test do
+  ruby 'scripts/command_performance.rb'
+end

--- a/expeditor.gemspec
+++ b/expeditor.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "concurrent-ruby", ">= 1.0.0"
   spec.add_runtime_dependency "retryable", "> 1.0"
 
+  spec.add_development_dependency "benchmark-ips"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "concurrent-ruby-ext", ">= 1.0.0"
   spec.add_development_dependency "rake"

--- a/scripts/command_performance.rb
+++ b/scripts/command_performance.rb
@@ -1,0 +1,25 @@
+$LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
+require 'expeditor'
+
+require 'benchmark/ips'
+
+Benchmark.ips do |x|
+  x.report("simple command") do |i|
+    executor = Concurrent::ThreadPoolExecutor.new(min_threads: 100, max_threads: 100, max_queue: 100)
+    service = Expeditor::Service.new(period: 10, non_break_count: 0, threshold: 0.5, sleep: 1, executor: executor)
+
+    i.times do
+      commands = 10000.times.map do
+        Expeditor::Command.new { 1 }.start
+      end
+      command = Expeditor::Command.new(service: service, dependencies: commands) do |*vs|
+        vs.inject(0, &:+)
+      end.start
+      command.get
+
+      service.reset_status!
+    end
+  end
+
+  x.compare!
+end


### PR DESCRIPTION
Fix possible race condition: If 2 commands (A, B) are given where both
commands have same Service instance (S). Both commands run and called
Service#open? at the same moment. Thread for A (thA) proceed to calling
Service#calc_open in calling Service#open?, then Service#calc_open
returned `true` at that time. At next moment, S's `@breaking` was set to
`true` in thA, then the thread scheduler decided to switch to run thB.
In thB, Service#open? was just called but since `@breaking` was set to
`true` by thA just a memont ago. So thB goes into if-then branch and
refer `@break_start`. The problem is here, the `@breaking` was set by
thA but `@break_start` was not yet set by thA, so thB's next
computation, which is `Time.now - @break_start` goes wrong result.

To fix the problem, simply synchronize all of the computations in
Service#open? and make the method an atom action.

AFAIK, Service#reset_status! is used only in a test environment, so just add doc comment not to use from different threads and leave it as it is.

@cookpad/dev-infra How about this? I hope all are well, but I might miss somethig.