### PR TITLE
Set larger sleep_time to be more stable test

### DIFF
--- a/spec/expeditor/command_spec.rb
+++ b/spec/expeditor/command_spec.rb
@@ -240,6 +240,8 @@ RSpec.describe Expeditor::Command do
     end
 
     context 'with fallback but normal success' do
+      let(:sleep_time) { 10 }
+
       it 'should not wait fallback execution' do
         command = simple_command(42).set_fallback do
           sleep sleep_time


### PR DESCRIPTION
Since we don't wait this `sleep_time` and this makes the test case
more clear.

Ref: https://travis-ci.org/cookpad/expeditor/jobs/227522168

@cookpad/dev-infra FYI