### PR TITLE
Implement sleep feature on circuit breaker

### DIFF
--- a/lib/expeditor/command.rb
+++ b/lib/expeditor/command.rb
@@ -227,9 +227,7 @@ module Expeditor
     end
 
     def breakable_block(args, &block)
-      if @service.open?
-        raise CircuitBreakError
-      else
+      @service.run_if_allowed do
         block.call(*args)
       end
     end

--- a/lib/expeditor/services/default.rb
+++ b/lib/expeditor/services/default.rb
@@ -28,8 +28,8 @@ module Expeditor
       def dependency
       end
 
-      def open?
-        false
+      def run_if_allowed
+        yield
       end
     end
   end

--- a/spec/expeditor/circuit_break_function_spec.rb
+++ b/spec/expeditor/circuit_break_function_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Expeditor::Command do
     context 'with circuit break' do
       it 'should reject execution' do
         executor = Concurrent::ThreadPoolExecutor.new(max_queue: 0)
-        service = Expeditor::Service.new(executor: executor, threshold: 0.0, non_break_count: 2, sleep: 0, period: 10)
+        service = Expeditor::Service.new(executor: executor, threshold: 0.1, non_break_count: 2, sleep: 1, period: 10)
 
         3.times do
           Expeditor::Command.new(service: service) do
@@ -120,15 +120,11 @@ RSpec.describe Expeditor::Command do
       end
     end
 
-    context 'with dependency\'s error of circuit break ' do
+    context "with dependency's error of circuit break" do
+      let(:executor) { Concurrent::ThreadPoolExecutor.new(max_threads: 100) }
+      let(:service) { Expeditor::Service.new(executor: executor, threshold: 0.2, non_break_count: 10, period: 10, sleep: 5) }
+
       it 'should not fall deadlock' do
-        service = Expeditor::Service.new(
-          executor: Concurrent::ThreadPoolExecutor.new(max_threads: 100),
-          threshold: 0.2,
-          non_break_count: 10,
-          period: 10,
-          sleep: 0,
-        )
         failure_commands = 20.times.map do
           Expeditor::Command.new(service: service) do
             raise RuntimeError

--- a/spec/expeditor/circuit_break_function_spec.rb
+++ b/spec/expeditor/circuit_break_function_spec.rb
@@ -37,8 +37,6 @@ RSpec.describe Expeditor::Command do
 
     context 'with circuit break and wait' do
       it 'should reject execution and back' do
-        skip 'Need half-open state for circuit breaker'
-
         sleep_value = 0.03
         config = { threshold: 0.1, non_break_count: 5, sleep: sleep_value, period: 0.1 }
         service = Expeditor::Service.new(config)


### PR DESCRIPTION
The naive implementation of sleep feature is aad8f17, but the problem is shown by 5cebcec that we want to allow only single requests when test the service is back to healthy or not. So I changed the interface by 1b8a21b.

@cookpad/dev-infra Please take a look at this.