### PR TITLE
CI: Use 2.4.6, 2.5.5, 2.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: ruby
-sudo: false
 cache: bundler
 rvm:
   - 2.1.10
-  - 2.2.8
-  - 2.3.5
-  - 2.4.2
+  - 2.2.10
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
+  - 2.6.2
   - ruby-head
 matrix:
   allow_failures:


### PR DESCRIPTION
This PR updates CI matrix to latest available versions.

Also: Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration