### PR TITLE
Add :allowed_exceptions option to Expeditor::Command

### DIFF
--- a/lib/expeditor/command.rb
+++ b/lib/expeditor/command.rb
@@ -14,6 +14,7 @@ module Expeditor
       @service = opts.fetch(:service, Expeditor::Services.default)
       @timeout = opts[:timeout]
       @dependencies = opts.fetch(:dependencies, [])
+      @allowed_exceptions = opts.fetch(:allowed_exceptions, [])
 
       @normal_future = nil
       @retryable_options = Concurrent::IVar.new
@@ -234,7 +235,7 @@ module Expeditor
 
     def metrics(reason)
       case reason
-      when nil
+      when nil, *@allowed_exceptions
         @service.success
       when Timeout::Error
         @service.timeout


### PR DESCRIPTION
## Problem
I'm raising an exception on 4xx and 5xx responses inside `Expeditor::Command` block.

However, some of these exceptions may not mean the dependency service is down. For example, we do not want to raise `Expeditor::CircuitBreakError` when we got hundreds of 404 responses.

## Changes
Introduce the `:allowed_exceptions` option in `Expeditor::Command.new` to specify exceptions ignored for failure count.