### PR TITLE
Fix Ruby 2.7 keyword arguments deprecation warning

### DIFF
--- a/lib/expeditor/service.rb
+++ b/lib/expeditor/service.rb
@@ -108,7 +108,7 @@ module Expeditor
 
     def reset_status!
       @mutex.synchronize do
-        @rolling_number = Expeditor::RollingNumber.new(@rolling_number_opts)
+        @rolling_number = Expeditor::RollingNumber.new(**@rolling_number_opts)
         @breaking = false
         @break_start = nil
       end


### PR DESCRIPTION
This fixes the following warnings that are printed when using this gem with Ruby 2.7:

Running `bundle exec rspec` at expeditor master:

```
/Users/r7kamura/src/github.com/r7kamura/expeditor/lib/expeditor/service.rb:111: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/r7kamura/src/github.com/r7kamura/expeditor/lib/expeditor/rolling_number.rb:10: warning: The called method `initialize' is defined here
```