### PR TITLE
Make sure to unlock the Mutex lock in a spec

### DIFF
--- a/spec/expeditor/rich_future_spec.rb
+++ b/spec/expeditor/rich_future_spec.rb
@@ -242,9 +242,13 @@ RSpec.describe Expeditor::RichFuture do
           42
         end
         mutex.lock
-        future1.execute
-        future2.execute
-        expect { future3.execute }.to raise_error(Expeditor::RejectedExecutionError)
+        begin
+          future1.execute
+          future2.execute
+          expect { future3.execute }.to raise_error(Expeditor::RejectedExecutionError)
+        ensure
+          mutex.unlock
+        end
       end
     end
   end


### PR DESCRIPTION
Running `rake spec` on a clone of this repo stalls (doesn't return to the prompt), and here's a fix for that.